### PR TITLE
Dip/Strike fix, Greens function fix, added PyVQ options --levels, --traces

### DIFF
--- a/pyvq/pyvq.py
+++ b/pyvq/pyvq.py
@@ -37,10 +37,9 @@ except ImportError:
     numpy_available = False
     
 # ----------------- Global constants -------------------------------------------
-MAP_WIDTH = 690.0
-MAP_HEIGHT = 422.0
-MIN_LON_DIFF = 0.035   # 1 corresponds to ~ 100km at lat,lon = (40.35, -124.85)
-MIN_LAT_DIFF = MIN_LON_DIFF*MAP_HEIGHT/MAP_WIDTH   # 0.8 corresponds to ~ 100km at lat,lon = (40.35, -124.85)
+LAT_LON_DIFF_FACTOR = 1.333 
+MIN_LON_DIFF = 0.01   # 1 corresponds to ~ 100km at lat,lon = (40.35, -124.85)
+MIN_LAT_DIFF = MIN_LON_DIFF/LAT_LON_DIFF_FACTOR   # 0.8 corresponds to ~ 100km at lat,lon = (40.35, -124.85)
 MIN_FIT_MAG  = 5.0     # lower end of magnitude for fitting freq_mag plot with b=1 curve
 
 #-------------------------------------------------------------------------------
@@ -53,9 +52,15 @@ def linear_interp(x, x_min, x_max, y_min, y_max):
 
 class SaveFile:
     def event_plot(self, event_file, plot_type):
+        # Remove any folders in front of model_file name
+        if len(model_file.split("/")) > 1:
+            model_file = model_file.split("/")[-1]
         return plot_type+"_"+event_file.split(".")[0]+".png"
         
     def field_plot(self, model_file, field_type, uniform_slip, event_id):
+        # Remove any folders in front of model_file name
+        if len(model_file.split("/")) > 1:
+            model_file = model_file.split("/")[-1]
         if uniform_slip is None and event_id is not None:
             return model_file.split(".")[0]+"_"+field_type+"_event"+str(event_id)+".png"
         elif uniform_slip is not None and event_id is None:

--- a/quakelib/src/QuakeLib.h
+++ b/quakelib/src/QuakeLib.h
@@ -206,7 +206,7 @@ namespace quakelib {
                 _static_strength = _dynamic_strength = _max_slip = std::numeric_limits<double>::quiet_NaN();
             };
 
-            //! Returns a unit vector along the direction of fault dip.
+            //! Returns the dip angle.
             double dip(void) const {
                 return normal().vector_angle(Vec<3>(0,0,1));
             };
@@ -288,14 +288,17 @@ namespace quakelib {
 
             //! Returns the angle of the element relative to north. Positive rotating clockwise from north.
             double strike(void) const {
-                Vec<3> north, v;
+                Vec<3> v;
                 v = _vert[2]-_vert[0];
-                // Handle the case when v points west 
-                if (v[0] < 0.0) {
-                    v = _vert[0]-_vert[2];
+                double strike;
+                // Handle the various quadrants differently
+                // atan2(y,x) return counter-clock angle from (x,y)=(1,0) aka East
+                if (v[1] >= 0 && v[0] < 0) {
+                    strike = 5*M_PI/2 - atan2(v[1],v[0]);
+                } else {
+                    strike = M_PI/2 - atan2(v[1],v[0]);
                 }
-                north[1] = 1.0;
-                return (v.vector_angle(north));
+                return (strike);
             };
     };
 

--- a/quakelib/src/QuakeLib.h
+++ b/quakelib/src/QuakeLib.h
@@ -207,8 +207,23 @@ namespace quakelib {
             };
 
             //! Returns the dip angle.
+            // Kasey re-writing the function. It looks like the cross product messes
+            // up dip when you switch the strike direction
             double dip(void) const {
                 return normal().vector_angle(Vec<3>(0,0,1));
+                //Vec<3> down_dip, horiz;
+                //down_dip = _vert[1]-_vert[0];
+                // Define the horizontal vector in same x/y direction as the down_dip vector
+                // Catch vertical strike slip cases and handle them specially
+                //if ((down_dip[0] == 0 || down_dip[0] == -0) && (down_dip[1] == 0 || down_dip[1] == -0)){
+                //    horiz[0] = 1.0;
+                //    horiz[1] = 1.0;
+                //} else {
+                //    horiz[0] = down_dip[0];
+                //    horiz[1] = down_dip[1];
+                //}
+                //horiz[2] = 0.0;
+                //return down_dip.vector_angle(horiz);
             };
 
             //! Returns unit vector along the direction of fault rake.
@@ -279,24 +294,27 @@ namespace quakelib {
             };
 
             //! Get the normal unit vector to the plane of this element.
+            // Kasey switching order of cross product to reflect the VQ convention
+            // that faults dip to the left of the strike direction. (corrected from a x b to b x a)
             Vec<3> normal(void) const {
                 Vec<3> a,b;
                 a=_vert[1]-_vert[0];
                 b=_vert[2]-_vert[0];
-                return a.cross(b).unit_vector();
+                return b.cross(a).unit_vector();
             };
 
             //! Returns the angle of the element relative to north. Positive rotating clockwise from north.
             double strike(void) const {
-                Vec<3> v;
+                Vec<3> v, north;
+                north[1] = 1.0;
                 v = _vert[2]-_vert[0];
+                v[2] = 0.0; 
                 double strike;
-                // Handle the various quadrants differently
-                // atan2(y,x) return counter-clock angle from (x,y)=(1,0) aka East
-                if (v[1] >= 0 && v[0] < 0) {
-                    strike = 5*M_PI/2 - atan2(v[1],v[0]);
+                // Handle the case where strike has a westward component
+                if (v[0] < 0.0) {
+                    strike = 2*M_PI - north.vector_angle(v);
                 } else {
-                    strike = M_PI/2 - atan2(v[1],v[0]);
+                    strike = north.vector_angle(v);
                 }
                 return (strike);
             };

--- a/quakelib/src/QuakeLib.h
+++ b/quakelib/src/QuakeLib.h
@@ -286,14 +286,16 @@ namespace quakelib {
                 return a.cross(b).unit_vector();
             };
 
-            //! Returns the angle of the element relative to north. Positive rotating west, negitive rotating east.
+            //! Returns the angle of the element relative to north. Positive rotating clockwise from north.
             double strike(void) const {
-                Vec<3> v1, v2, norm;
-                norm = normal();
-                v1[0] = norm[0];
-                v1[1] = norm[1];
-                v2[1] = 1.0;
-                return (v1.vector_angle(v2) - M_PI/2.0);
+                Vec<3> north, v;
+                v = _vert[2]-_vert[0];
+                // Handle the case when v points west 
+                if (v[0] < 0.0) {
+                    v = _vert[0]-_vert[2];
+                }
+                north[1] = 1.0;
+                return (v.vector_angle(north));
             };
     };
 

--- a/quakelib/src/QuakeLibElement.cpp
+++ b/quakelib/src/QuakeLibElement.cpp
@@ -249,7 +249,7 @@ quakelib::FloatList quakelib::SlipMap::gravity_changes(const VectorList &points,
         xp3 = involved_elements[ele_id].implicit_vert()[0];
         yp3 = involved_elements[ele_id].implicit_vert()[1];
         
-        
+        /*
         std::cout << "v1: <" << involved_elements[ele_id].vert(0)[0] << ", " << involved_elements[ele_id].vert(0)[1] << ", " << involved_elements[ele_id].vert(0)[2] << ">" << std::endl;
         std::cout << "v2: <" << involved_elements[ele_id].vert(1)[0] << ", " << involved_elements[ele_id].vert(1)[1] << ", " << involved_elements[ele_id].vert(1)[2] << ">" << std::endl;
         std::cout << "v3: <" << involved_elements[ele_id].vert(2)[0] << ", " << involved_elements[ele_id].vert(2)[1] << ", " << involved_elements[ele_id].vert(2)[2] << ">" << std::endl;
@@ -260,12 +260,12 @@ quakelib::FloatList quakelib::SlipMap::gravity_changes(const VectorList &points,
         std::cout << "US: " << US << std::endl;
         std::cout << "UD: " << UD << std::endl;
         std::cout << "UT: " << UT << std::endl;
-        std::cout << "dip: " << dip << std::endl;
-        std::cout << "rake: " << involved_elements[ele_id].rake() << std::endl;
-        std::cout << "strike: " << strike << std::endl;
+        std::cout << "dip: " << dip*180.0/M_PI << std::endl;
+        std::cout << "rake: " << involved_elements[ele_id].rake()*180.0/M_PI << std::endl;
+        std::cout << "strike: " << strike*180.0/M_PI << std::endl;
         std::cout << "xp0: " << xp0 << std::endl;
         std::cout << "yp0: " << yp0 << std::endl;
-
+        */
 
         for (VectorList::size_type point_id = 0; point_id != points.size(); point_id++) {
             x = points[point_id][0];

--- a/quakelib/src/QuakeLibElement.cpp
+++ b/quakelib/src/QuakeLibElement.cpp
@@ -210,7 +210,7 @@ quakelib::FloatList quakelib::SlipMap::gravity_changes(const VectorList &points,
 
     for (SlippedElementList::size_type ele_id = 0; ele_id != involved_elements.size(); ele_id++) {
         slip = involved_elements[ele_id].slip();
-        c = involved_elements[ele_id].max_depth();
+        c = fabs(involved_elements[ele_id].max_depth());
         rake_cos = cos(involved_elements[ele_id].rake());
         rake_sin = sin(involved_elements[ele_id].rake());
 
@@ -248,6 +248,24 @@ quakelib::FloatList quakelib::SlipMap::gravity_changes(const VectorList &points,
 
         xp3 = involved_elements[ele_id].implicit_vert()[0];
         yp3 = involved_elements[ele_id].implicit_vert()[1];
+        
+        
+        std::cout << "v1: <" << involved_elements[ele_id].vert(0)[0] << ", " << involved_elements[ele_id].vert(0)[1] << ", " << involved_elements[ele_id].vert(0)[2] << ">" << std::endl;
+        std::cout << "v2: <" << involved_elements[ele_id].vert(1)[0] << ", " << involved_elements[ele_id].vert(1)[1] << ", " << involved_elements[ele_id].vert(1)[2] << ">" << std::endl;
+        std::cout << "v3: <" << involved_elements[ele_id].vert(2)[0] << ", " << involved_elements[ele_id].vert(2)[1] << ", " << involved_elements[ele_id].vert(2)[2] << ">" << std::endl;
+        std::cout << "v4: <" << involved_elements[ele_id].implicit_vert()[0] << ", " << involved_elements[ele_id].implicit_vert()[1] << ", " << involved_elements[ele_id].implicit_vert()[2] << ">" << std::endl;
+        std::cout << "L: " << L << std::endl;
+        std::cout << "W: " << W << std::endl;
+        std::cout << "c: " << c << std::endl;
+        std::cout << "US: " << US << std::endl;
+        std::cout << "UD: " << UD << std::endl;
+        std::cout << "UT: " << UT << std::endl;
+        std::cout << "dip: " << dip << std::endl;
+        std::cout << "rake: " << involved_elements[ele_id].rake() << std::endl;
+        std::cout << "strike: " << strike << std::endl;
+        std::cout << "xp0: " << xp0 << std::endl;
+        std::cout << "yp0: " << yp0 << std::endl;
+
 
         for (VectorList::size_type point_id = 0; point_id != points.size(); point_id++) {
             x = points[point_id][0];
@@ -543,5 +561,3 @@ quakelib::FloatList quakelib::SlipMap::potential_changes(const VectorList &point
 
     return potential_changes;
 }
-
-

--- a/quakelib/src/QuakeLibOkada.cpp
+++ b/quakelib/src/QuakeLibOkada.cpp
@@ -2950,6 +2950,7 @@ double quakelib::Okada::calc_dg(Vec<2> location, double c, double dip, double L,
     // Everything is in M-K-S units
     double G   = 0.000000000066738; //Big G gravitation constant
     double RHO = 2670.0;   //mean crustal density (rough estimate)
+    double RHO_prime = 0.0;   //density of cavity-filling matter, mean ocean water density  1030
     double B   = 0.00000309; //free-air gravity gradient (taken from Okubo '92)
 
     double _p = p(location[1],0.0,c);
@@ -2987,7 +2988,7 @@ double quakelib::Okada::calc_dg(Vec<2> location, double c, double dip, double L,
 
     double dgFree = B*displace[2];
 
-    return RHO*G*(dgS + dgD + dgT + dgC) - dgFree;
+    return RHO*G*(dgS + dgD + dgT) + (RHO_prime - RHO)*G*dgC - dgFree;
 }
 //
 // double bar evaluation (chinnery)
@@ -3128,8 +3129,8 @@ double quakelib::Okada::calc_dV(Vec<3> location, double c, double dip, double L,
 
     // Everything is in M-K-S units
     double G    = 0.000000000066738; //Big G gravitation constant
-    double RHO  = 2900.0;   //mean ocean crustal density (rough estimate)
-    double RHOw = 1030.0;   //mean ocean water density
+    double RHO  = 2670.0;   //mean ocean crustal density (rough estimate) 2900
+    double RHO_prime =    0.0;   //density of cavity-filling matter, mean ocean water density  1030
     //gravitational potential changes will be evaluated on the seafloor
     //initally so cavities will fill with water (probably irrelevant
     //since I don't think we have any tensile faults)
@@ -3159,7 +3160,7 @@ double quakelib::Okada::calc_dV(Vec<3> location, double c, double dip, double L,
 
     // here displacement vector used to get the height change in the halfspace at (x,y,z)
 
-    return RHO*G*(dvS + dvD + dvT) + G*(RHOw-RHO)*dvC;
+    return RHO*G*(dvS + dvD + dvT) + G*(RHO_prime - RHO)*dvC;
 }
 //
 // double bar evaluation (chinnery)
@@ -3348,6 +3349,7 @@ double quakelib::Okada::calc_dg_dilat(Vec<2> location, double c, double dip, dou
     // Everything is in M-K-S units
     double G   = 0.000000000066738; //Big G gravitation constant
     double RHO = 2670.0;   //mean crustal density (rough estimate)
+    double RHO_prime = 0.0; // density of cavity filling matter
 
     double _p = p(location[1],0.0,c);
     double _q = q(location[1],0.0,c);
@@ -3355,7 +3357,6 @@ double quakelib::Okada::calc_dg_dilat(Vec<2> location, double c, double dip, dou
     double dgD_star= 0.0; //Dip
     double dgT_star= 0.0; //Tensile
     double dgC_star= 0.0; //Cavitation, currently disabled.
-    //To enable, uncomment and specify DENSITY_DIFF
 
     if (US != 0.0) {
         OP_MULT(1);
@@ -3370,8 +3371,8 @@ double quakelib::Okada::calc_dg_dilat(Vec<2> location, double c, double dip, dou
     if (UT != 0.0) {
         OP_MULT(2);
         dgT_star = UT*dTg_star(location[0],_p,_q,L,W);
-        //dgC_star = DENSITY_DIFF*G*UT*dCg(location[0],_p,_q,L,W);
-        //In Okubo, Cg and Cg* are the same
+        dgC_star = (RHO_prime - RHO)*G*UT*dCg(location[0],_p,_q,L,W);
+        //In Okubo 1992, Cg and Cg* are the same
     }
 
     return RHO*G*(dgS_star + dgD_star + dgT_star) + dgC_star;
@@ -3485,6 +3486,7 @@ double quakelib::Okada::I0g(double _R, double eta, double _q) {
 
     return ret_value;
 }
+
 
 
 

--- a/quakelib/src/QuakeLibOkada.h
+++ b/quakelib/src/QuakeLibOkada.h
@@ -556,9 +556,6 @@ namespace quakelib {
             //
 
 
-
-
-
             //
             //Added by KWS, below is for change in gravitational potential
             //
@@ -576,6 +573,22 @@ namespace quakelib {
             double Cv(double xi, double eta, double _q);
             double I0v(double _R, double eta, double _q);
             double I1v(double _R, double xi, double eta, double _q);
+            
+            
+            //
+            // dg test (dg2)
+            // components
+            double dSh(double x, double _p, double _q, double L, double W);
+            double dDh(double x, double _p, double _q, double L, double W);
+            double dTh(double x, double _p, double _q, double L, double W);
+            // globals
+            double Sh(double xi, double eta, double _q);
+            double Dh(double xi, double eta, double _q);
+            double Th(double xi, double eta, double _q);
+            double I1h(double _R, double xi, double eta, double _q);
+            double I4h(double _R, double xi, double eta, double _q);
+            double I5h(double _R, double xi, double eta, double _q);
+            
     };
 }
 


### PR DESCRIPTION
SimElement:   Fixed the handling of Strike angle to match convention that 0 < strike < 2*pi

SimElement: Fixed the order of the cross product to find an element's normal vector to match the VQ mesher convention that faults dip to the left of the strike direction. This change will affect the computed dip angles for sim elements.

QuakeLibOkada: Fixed the sign on the maximum depth for the fault. Green's functions now match those presented in Okubo 1992, with the caveat that there's still some small location error that is fixed when increasing mesh resolution. e.g. gravity field for a single thrust fault does not match expected pattern, but meshing the fault into 10+ elements fixes the field and it agrees with the expected pattern.

--traces option for pyvq:   Will plot fault traces given a fault model, can be used in conjunction with --use_sections to highlight specific sections

--levels option for pyvq:  Used to draw contours on field plots (e.g. --levels -50 -20 -10 0 10 20 50)