### PR TITLE
Stabilizing VQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,11 +160,13 @@ xcuserdata
 xcode/
 doc/#vc.lyx#
 doc/vc.lyx~
+VQ.xcodeproj/
 
 examples/ca_model/all_cal*
 examples/ca_model/events*
 examples/ca_model/sweeps*
 
+examples/ca_model/gen_norcal_model.sh
 
 doc/*.log
 
@@ -182,6 +184,7 @@ doc/*.bbl
 
 doc/*.blg
 
+doc/*.pdf
 
 *.h5
 

--- a/PyVQ/pyvq/betas/greens.py
+++ b/PyVQ/pyvq/betas/greens.py
@@ -18,7 +18,7 @@ import itertools
 import scipy.optimize
 from scipy.stats import norm
 
-import sys
+import sys, os
 
 
 class PyGreens(object):

--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -8,6 +8,7 @@ import argparse
 import quakelib
 import gc
 import operator
+import os
 
 scipy_available = True
 try:
@@ -2149,7 +2150,10 @@ if __name__ == "__main__":
 
     # Read the event and sweeps files
     if args.event_file:
-        events = Events(args.event_file, args.sweep_file)
+        if not os.path.isfile(args.event_file):
+            raise "Event file does not exist: "+args.event_file
+        else:
+            events = Events(args.event_file, args.sweep_file)
 
     # Read the geometry model if specified
     if args.model_file:

--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -218,7 +218,7 @@ class TriggerSectionFilter:
         return ""
         
 class SlipFilter:
-    def __init__(self, geometry, min_slip=None, max_slip=None):
+    def __init__(self, min_slip=None, max_slip=None):
         self._min_slip = min_slip if min_slip is not None else -float("inf")
         self._max_slip = max_slip if max_slip is not None else float("inf")
 
@@ -344,21 +344,21 @@ class Events:
             raise "No events matching filters found!"
 
     def interevent_times(self):
-        event_times = [self._events[evnum].getEventYear() for evnum in self._filtered_events]
+        event_times = [self._events[evnum].getEventYear() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]
         return [event_times[i+1]-event_times[i] for i in xrange(len(event_times)-1)]
 
     def event_years(self):
-        return [self._events[evnum].getEventYear() for evnum in self._filtered_events]
+        return [self._events[evnum].getEventYear() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]
 
     def event_rupture_areas(self):
-        return [self._events[evnum].calcEventRuptureArea() for evnum in self._filtered_events]
+        return [self._events[evnum].calcEventRuptureArea() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]
 
     def event_magnitudes(self):
-        return [self._events[evnum].getMagnitude() for evnum in self._filtered_events if (self._events[evnum].getMagnitude() != float("-inf") or np.isnan(self._events[evnum].getMagnitude()))]
-# TODO: Handle -infinity or NaN magnitudes on the C++ side
+        return [self._events[evnum].getMagnitude() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]
+# TODO: Handle  NaN magnitudes on the C++ side
 
     def event_mean_slip(self):
-        return [self._events[evnum].calcMeanSlip() for evnum in self._filtered_events]
+        return [self._events[evnum].calcMeanSlip() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]
         
     def get_event_element_slips(self, evnum):
         element_ids = self._events[evnum].getInvolvedElements()
@@ -393,19 +393,19 @@ class Events:
         self.event_summary(evnums)
     
     def event_initial_shear_stresses(self):
-        return [self._events[evnum].getShearStressInit() for evnum in self._filtered_events]
+        return [self._events[evnum].getShearStressInit() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]
 
     def event_final_shear_stresses(self):
-        return [self._events[evnum].getShearStressFinal() for evnum in self._filtered_events]        
+        return [self._events[evnum].getShearStressFinal() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]        
                         
     def event_initial_normal_stresses(self):
-        return [self._events[evnum].getNormalStressInit() for evnum in self._filtered_events]
+        return [self._events[evnum].getNormalStressInit() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]
 
     def event_final_normal_stresses(self):
-        return [self._events[evnum].getNormalStressFinal() for evnum in self._filtered_events]  
+        return [self._events[evnum].getNormalStressFinal() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())]  
         
     def number_of_sweeps(self):
-        return [self._events[evnum].getNumRecordedSweeps() for evnum in self._filtered_events] 
+        return [self._events[evnum].getNumRecordedSweeps() for evnum in self._filtered_events if not np.isnan(self._events[evnum].getMagnitude())] 
 
 class Sweeps:
     # A class for reading/analyzing data from the event sweeps

--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -2184,6 +2184,8 @@ if __name__ == "__main__":
         event_filters.append(YearFilter(min_year=args.min_year, max_year=args.max_year))
 
     if args.min_slip or args.max_slip:
+        # Setting default lower limit on mean slip of 1cm
+        if args.min_slip is None: args.min_slip = 0.01
         event_filters.append(SlipFilter(min_slip=args.min_slip, max_slip=args.max_slip))
 
     if args.min_event_num or args.max_event_num:

--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -102,7 +102,7 @@ class SaveFile:
         min_mag = str(min_mag)
         # Remove any folders in front of model_file name
         if len(event_file.split("/")) > 1:
-            model_file = model_file.split("/")[-1]
+            event_file = event_file.split("/")[-1]
         if min_mag is not None: 
             # e.g. min_mag = 7.5, filename has '7-5'
             if len(min_mag.split(".")) > 1:
@@ -215,6 +215,21 @@ class TriggerSectionFilter:
 
     def plot_str(self):
         return ""
+        
+class SlipFilter:
+    def __init__(self, geometry, min_slip=None, max_slip=None):
+        self._min_slip = min_slip if min_slip is not None else -float("inf")
+        self._max_slip = max_slip if max_slip is not None else float("inf")
+
+    def test_event(self, event):
+        return (event.calcMeanSlip() >= self._min_slip and event.calcMeanSlip() <= self._max_slip)
+
+    def plot_str(self):
+        label_str = ""
+# TODO: change to <= character
+        if self._min_slip != -float("inf"): label_str += str(self._min_slip)+"<"
+        if self._max_slip != float("inf"): label_str += "year<"+str(self._max_slip)
+        return label_str
         
 class Geometry:
     def __init__(self, model_file=None, model_file_type=None):
@@ -338,8 +353,8 @@ class Events:
         return [self._events[evnum].calcEventRuptureArea() for evnum in self._filtered_events]
 
     def event_magnitudes(self):
-        return [self._events[evnum].getMagnitude() for evnum in self._filtered_events if self._events[evnum].getMagnitude() != float("-inf")]
-# TODO: Handle -infinity magnitudes on the C++ side
+        return [self._events[evnum].getMagnitude() for evnum in self._filtered_events if (self._events[evnum].getMagnitude() != float("-inf") or np.isnan(self._events[evnum].getMagnitude()))]
+# TODO: Handle -infinity or NaN magnitudes on the C++ side
 
     def event_mean_slip(self):
         return [self._events[evnum].calcMeanSlip() for evnum in self._filtered_events]
@@ -567,15 +582,9 @@ class GreensPlotter:
         cbar_ax.tick_params(axis='x',labelbottom=BOTTOM,labeltop=TOP,
                         bottom='off',top='off',right='off',left='off',pad=PAD)
         if self.field_type == "gravity" or self.field_type == "dilat_gravity":
-            if self.levels is not None:
-                forced_ticks = self.levels
-            else:
-                forced_ticks  = [int(num) for num in np.linspace(-self.cbar_max, self.cbar_max, 11)]
+            forced_ticks  = [int(num) for num in np.linspace(-self.cbar_max, self.cbar_max, len(cbar_ax.xaxis.get_ticklabels()))]
         else:
-            if self.levels is not None:
-                forced_ticks = self.levels
-            else:
-                forced_ticks  = [round(num, 3) for num in np.linspace(-self.cbar_max, self.cbar_max, 11)]
+            forced_ticks  = [round(num, 3) for num in np.linspace(-self.cbar_max, self.cbar_max, len(cbar_ax.xaxis.get_ticklabels()))]
         cb_tick_labs    = [str(num) for num in forced_ticks]
         cb_tick_labs[0] = '<'+cb_tick_labs[0]
         cb_tick_labs[-1]= '>'+cb_tick_labs[-1]
@@ -1677,6 +1686,7 @@ class BasePlotter:
             ax.plot(line_x, line_y, label = line_label, ls='-', c = 'k', lw=2)
             ax.legend(loc = "best")
         ax.get_xaxis().get_major_formatter().set_useOffset(False)
+        
         plt.savefig(filename,dpi=100)
         sys.stdout.write("Plot saved: {}\n".format(filename))
         
@@ -1791,7 +1801,7 @@ class DiagnosticPlot(BasePlotter):
         stress_changes = (shear_final-shear_init)/shear_init
         # Generate the binned averages too
         x_ave, y_ave = calculate_averages(years,stress_changes,log_bin=False,num_bins=20)
-        self.scatter_and_line(True, years, stress_changes, x_ave, y_ave, "binned average", "Event shear stress changes", "simulation time [years]", "fractional change", filename)
+        self.scatter_and_line(False, years, stress_changes, x_ave, y_ave, "binned average", "Event shear stress changes", "simulation time [years]", "fractional change", filename)
         
     def plot_normal_stress_changes(self, events, filename):
         normal_init = np.array(events.event_initial_normal_stresses())
@@ -2014,6 +2024,10 @@ if __name__ == "__main__":
             help="Minimum year of events to process.")
     parser.add_argument('--max_year', type=float, required=False,
             help="Maximum year of events to process.")
+    parser.add_argument('--min_slip', type=float, required=False,
+            help="Minimum mean slip of events to process.")
+    parser.add_argument('--max_slip', type=float, required=False,
+            help="Maximum mean slip of events to process.")
     parser.add_argument('--min_event_num', type=float, required=False,
             help="Minimum event number of events to process.")
     parser.add_argument('--max_event_num', type=float, required=False,
@@ -2165,6 +2179,9 @@ if __name__ == "__main__":
     if args.min_year or args.max_year:
         event_filters.append(YearFilter(min_year=args.min_year, max_year=args.max_year))
 
+    if args.min_slip or args.max_slip:
+        event_filters.append(SlipFilter(min_slip=args.min_slip, max_slip=args.max_slip))
+
     if args.min_event_num or args.max_event_num:
         event_filters.append(EventNumFilter(min_mag=args.min_event_num, max_mag=args.max_event_num))
 
@@ -2187,6 +2204,15 @@ if __name__ == "__main__":
         events.largest_event_summary(args.summary)
 
     # Generate plots
+    if args.diagnostics:
+        args.num_sweeps = True
+        args.event_shear_stress = True
+        args.event_normal_stress = True
+        args.event_mean_slip = True
+        args.plot_freq_mag = 3
+        args.plot_mag_mean_slip = True
+        args.plot_mag_rupt_area = True
+        args.wc94 = True
     if args.plot_freq_mag:
         filename = SaveFile().event_plot(args.event_file, "freq_mag", args.min_magnitude)
         if args.plot_freq_mag == 1: UCERF2,b1 = False, False
@@ -2293,12 +2319,6 @@ if __name__ == "__main__":
 # TODO: check that stress_set is valid
         StressHistoryPlot().plot(stress_set, args.stress_elements)
         
-    # Generate the diagnostic plots
-    if args.diagnostics:
-        args.num_sweeps = True
-        args.event_shear_stress = True
-        args.event_normal_stress = True
-        args.event_mean_slip = True
     if args.num_sweeps:
         filename = SaveFile().diagnostic_plot(args.event_file, "num_sweeps")
         DiagnosticPlot().plot_number_of_sweeps(events, filename)

--- a/quakelib/src/QuakeLib.h
+++ b/quakelib/src/QuakeLib.h
@@ -269,6 +269,14 @@ namespace quakelib {
             double largest_dimension(void) const {
                 return fmax((_vert[2]-_vert[0]).mag(),(_vert[1]-_vert[0]).mag());
             };
+            
+            double length(void) const {
+                return (_vert[2]-_vert[0]).mag();
+            };
+            
+            double width(void) const {
+                return (_vert[1]-_vert[0]).mag();
+            };
 
             //! Determine minimum depth of this block.
             //! Note that depth is negative, so max depth returns the most negative point and min depth the least negative

--- a/quakelib/src/QuakeLib.h
+++ b/quakelib/src/QuakeLib.h
@@ -115,7 +115,7 @@ namespace quakelib {
 
                 return _vert[vert];
             };
-            
+
             //! Set the distance along strike of a vertex.
             void set_das(const unsigned int &vert, const double &new_das) throw(std::out_of_range) {
                 if (vert>=3) throw std::out_of_range("quakelib::Element::set_vert");
@@ -128,13 +128,13 @@ namespace quakelib {
 
                 return _das[vert];
             };
-            
+
             //! Get the maximum distance along strike of a vertex.
             double max_das(void) {
                 return std::max(_das[0], std::max(_das[1], _das[2]));
             };
-            
-            
+
+
             // For quadrilateral elements, calculate the implicit 4th point
             Vec<3> implicit_vert(void) const throw(std::out_of_range) {
                 if (!_is_quad) throw std::out_of_range("quakelib::Element::implicit_vert");
@@ -293,14 +293,6 @@ namespace quakelib {
             //! Returns length along largest dimension
             double largest_dimension(void) const {
                 return fmax((_vert[2]-_vert[0]).mag(),(_vert[1]-_vert[0]).mag());
-            };
-            
-            double length(void) const {
-                return (_vert[2]-_vert[0]).mag();
-            };
-            
-            double width(void) const {
-                return (_vert[1]-_vert[0]).mag();
             };
 
             //! Determine minimum depth of this block.

--- a/quakelib/src/QuakeLib.h
+++ b/quakelib/src/QuakeLib.h
@@ -62,6 +62,8 @@ namespace quakelib {
         protected:
             //! Coordinates of element vertices in meters
             Vec<3>      _vert[3];
+            //! Distance along strike for each vertex in meters
+            double      _das[3];
             //! Whether the vertices describe a triangle (false) or parallelogram (quadrilateral) (true)
             bool        _is_quad;
             //! Rake angle (radians, 0.0 = left lateral, PI/2 = positive side moves up)
@@ -113,6 +115,26 @@ namespace quakelib {
 
                 return _vert[vert];
             };
+            
+            //! Set the distance along strike of a vertex.
+            void set_das(const unsigned int &vert, const double &new_das) throw(std::out_of_range) {
+                if (vert>=3) throw std::out_of_range("quakelib::Element::set_vert");
+
+                _das[vert] = new_das;
+            };
+            //! Get the distance along strike of a vertex.
+            double das(const unsigned int &vert) const throw(std::out_of_range) {
+                if (vert>=3) throw std::out_of_range("quakelib::Element::vert");
+
+                return _das[vert];
+            };
+            
+            //! Get the maximum distance along strike of a vertex.
+            double max_das(void) {
+                return std::max(_das[0], std::max(_das[1], _das[2]));
+            };
+            
+            
             // For quadrilateral elements, calculate the implicit 4th point
             Vec<3> implicit_vert(void) const throw(std::out_of_range) {
                 if (!_is_quad) throw std::out_of_range("quakelib::Element::implicit_vert");
@@ -205,6 +227,9 @@ namespace quakelib {
                 _vert[0] = Vec<3>::nan_vec();
                 _vert[1] = Vec<3>::nan_vec();
                 _vert[2] = Vec<3>::nan_vec();
+                _das[0] = std::numeric_limits<double>::quiet_NaN();
+                _das[1] = std::numeric_limits<double>::quiet_NaN();
+                _das[2] = std::numeric_limits<double>::quiet_NaN();
                 _is_quad = false;
                 _rake = _slip_rate = _aseis_factor = std::numeric_limits<double>::quiet_NaN();
                 _lame_mu = _lame_lambda = std::numeric_limits<double>::quiet_NaN();

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -1603,6 +1603,7 @@ quakelib::SimElement quakelib::ModelWorld::create_sim_element(const UIndex &elem
     for (i=0; i<3; ++i) {
         vit = _vertices.find(eit->second.vertex(i));
         new_element.set_vert(i, vit->second.xyz());
+        new_element.set_das(i, vit->second.das());
     }
 
     new_element.set_is_quad(eit->second.is_quad());

--- a/src/core/Params.cpp
+++ b/src/core/Params.cpp
@@ -110,6 +110,8 @@ void VCParams::read_params(const std::string &param_file_name) {
     //
     // Kasey: parameter to either read in stress drops from file or compute them
     params.readSet<bool>("sim.friction.compute_stress_drops", true);
+    
+    params.readSet<double>("sim.friction.stress_drop_factor", 0.3);
 
 }
 

--- a/src/core/Params.cpp
+++ b/src/core/Params.cpp
@@ -87,13 +87,13 @@ void VCParams::read_params(const std::string &param_file_name) {
     params.readSet<string>("sim.file.output_stress_type", "");
     //
     // yoder: add parameters to truncate crazy greens function values:
-    //params.readSet<double>("sim.greens.shear_max",  std::numeric_limits<double>::max());        
+    //params.readSet<double>("sim.greens.shear_max",  std::numeric_limits<double>::max());
     //params.readSet<double>("sim.greens.shear_min",  -std::numeric_limits<double>::max());
     //params.readSet<double>("sim.greens.normal_max", std::numeric_limits<double>::max());
     //params.readSet<double>("sim.greens.normal_min", -std::numeric_limits<double>::max());
     //printf("**Debug: greens shear_max=%f, shear_min=%f\n",std::numeric_limits<double>::max(), std::numeric_limits<double>::min() );
     //
-    // yoder: 
+    // yoder:
     // it does not really make sense to filter the diagonal and off-diagonal elements together. it may not make sense to filter
     // diag. elements at all. anyway, let's be specific:
     params.readSet<double>("sim.greens.shear_diag_max",  DBL_MAX);
@@ -110,7 +110,7 @@ void VCParams::read_params(const std::string &param_file_name) {
     //
     // Kasey: parameter to either read in stress drops from file or compute them
     params.readSet<bool>("sim.friction.compute_stress_drops", true);
-    
+
     params.readSet<double>("sim.friction.stress_drop_factor", 0.3);
 
 }
@@ -127,37 +127,33 @@ void VCParams::write_params(const std::string &param_file_name) {
 double VCParams::getGreenShearMax(const int block_1, const int block_2) const {
     // return the appropriate (off)diagonal max/min greens values.
     if (block_1==block_2) {
-    	return getGreenShearDiagMax();
+        return getGreenShearDiagMax();
+    } else {
+        return getGreenShearOffDiagMax();
     }
-    else {
-    	return getGreenShearOffDiagMax();
-    }
-        };
+};
 double VCParams::getGreenShearMin(const int block_1, const int block_2) const {
     // return the appropriate (off)diagonal max/min greens values.
     if (block_1==block_2) {
-    	return getGreenShearDiagMin();
+        return getGreenShearDiagMin();
+    } else {
+        return getGreenShearOffDiagMin();
     }
-    else {
-    	return getGreenShearOffDiagMin();
-    }
-        };
-        
+};
+
 double VCParams::getGreenNormalMax(const int block_1, const int block_2) const {
     // return the appropriate (off)diagonal max/min greens values.
     if (block_1==block_2) {
-    	return getGreenNormalDiagMax();
+        return getGreenNormalDiagMax();
+    } else {
+        return getGreenNormalOffDiagMax();
     }
-    else {
-    	return getGreenNormalOffDiagMax();
-    }
-        };
+};
 double VCParams::getGreenNormalMin(const int block_1, const int block_2) const {
     // return the appropriate (off)diagonal max/min greens values.
     if (block_1==block_2) {
-    	return getGreenNormalDiagMin();
+        return getGreenNormalDiagMin();
+    } else {
+        return getGreenNormalOffDiagMin();
     }
-    else {
-    	return getGreenNormalOffDiagMin();
-    }
-        };
+};

--- a/src/core/Params.h
+++ b/src/core/Params.h
@@ -192,6 +192,13 @@ class VCParams {
         bool computeStressDrops(void) const {
             return params.read<bool>("sim.friction.compute_stress_drops");
         };
+        
+        // The constant adjustment to the stress drops, should be between 0.3 and 0.5 globally
+        //     with tuning the larger faults may need 0.6 to 0.8. The larger the number, the larger 
+        //     the stress drops. Currently it's a global constant
+        double stressDropFactor(void) const {
+            return params.read<double>("sim.friction.stress_drop_factor");
+        };
 
         //
         // yoder: and overload so we can easily distinguish (off)diagonal elements (defined in GreensInit.cpp)

--- a/src/core/Params.h
+++ b/src/core/Params.h
@@ -173,7 +173,7 @@ class VCParams {
         double getGreenShearMax(void) const {
             //return params.read<double>("sim.greens.shear_max");
             return params.read<double>("sim.greens.shear_offdiag_max");
-        };        
+        };
         double getGreenShearMin(void) const {
             //return params.read<double>("sim.greens.shear_min");
             return params.read<double>("sim.greens.shear_offdiag_min");
@@ -192,9 +192,9 @@ class VCParams {
         bool computeStressDrops(void) const {
             return params.read<bool>("sim.friction.compute_stress_drops");
         };
-        
+
         // The constant adjustment to the stress drops, should be between 0.3 and 0.5 globally
-        //     with tuning the larger faults may need 0.6 to 0.8. The larger the number, the larger 
+        //     with tuning the larger faults may need 0.6 to 0.8. The larger the number, the larger
         //     the stress drops. Currently it's a global constant
         double stressDropFactor(void) const {
             return params.read<double>("sim.friction.stress_drop_factor");
@@ -206,12 +206,12 @@ class VCParams {
         double getGreenShearMin(const int block_1, const int block_2) const;
         double getGreenNormalMax(const int block_1, const int block_2) const;
         double getGreenNormalMin(const int block_1, const int block_2) const;
-        
+
         //
         // yoder: ... and for (non)diag specific...
         double getGreenShearDiagMax(void) const {
             return params.read<double>("sim.greens.shear_diag_max");
-        };        
+        };
         double getGreenShearDiagMin(void) const {
             return params.read<double>("sim.greens.shear_diag_min");
         };
@@ -224,7 +224,7 @@ class VCParams {
         //
         double getGreenShearOffDiagMax(void) const {
             return params.read<double>("sim.greens.shear_offdiag_max");
-        };        
+        };
         double getGreenShearOffDiagMin(void) const {
             return params.read<double>("sim.greens.shear_offdiag_min");
         };
@@ -234,7 +234,7 @@ class VCParams {
         double getGreenNormalOffDiagMin(void) const {
             return params.read<double>("sim.greens.normal_offdiag_min");
         };
-        
+
 };
 
 #endif

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -1051,7 +1051,7 @@ void Simulation::setGreens(const BlockID &r, const BlockID &c, const double &new
     //
     greenShear()->setVal(getLocalInd(r), c, std::max(getGreenShearMin(r,c), std::min(new_green_shear, getGreenShearMax(r,c))));
     greenNormal()->setVal(getLocalInd(r), c, std::max(getGreenNormalMin(r,c), std::min(new_green_normal, getGreenNormalMax(r,c))));
-    
+
     // original update code:
     /*
     //greenShear()->setVal(getLocalInd(r), c, new_green_shear);

--- a/src/io/ReadModelFile.cpp
+++ b/src/io/ReadModelFile.cpp
@@ -75,7 +75,7 @@ void ReadModelFile::init(SimFramework *_sim) {
 
         // Set SimElement values
         for (unsigned int i=0; i<3; ++i) new_block.set_vert(i, new_element.vert(i));
-        
+
         // We also need distance along strike data for computing section length for computing stress drops
         for (unsigned int i=0; i<3; ++i) new_block.set_das(i, new_element.das(i));
 

--- a/src/io/ReadModelFile.cpp
+++ b/src/io/ReadModelFile.cpp
@@ -75,6 +75,9 @@ void ReadModelFile::init(SimFramework *_sim) {
 
         // Set SimElement values
         for (unsigned int i=0; i<3; ++i) new_block.set_vert(i, new_element.vert(i));
+        
+        // We also need distance along strike data for computing section length for computing stress drops
+        for (unsigned int i=0; i<3; ++i) new_block.set_das(i, new_element.das(i));
 
         new_block.set_is_quad(new_element.is_quad());
         new_block.set_rake(new_element.rake());

--- a/src/simulation/GreensInit.cpp
+++ b/src/simulation/GreensInit.cpp
@@ -119,9 +119,9 @@ void GreensInit::init(SimFramework *_sim) {
 
     sim->console() << "# Greens shear matrix takes " << abbr_shear_bytes << " " << space_vals[shear_ind] << std::endl;
     sim->console() << "# Greens normal matrix takes " << abbr_normal_bytes << " " << space_vals[norm_ind] << std::endl;
-	//
-	// yoder: print some greens max/min/mean stats:
-	// (and this information becoming less interesting with the introduction of (off)diagonal specific data).
+    //
+    // yoder: print some greens max/min/mean stats:
+    // (and this information becoming less interesting with the introduction of (off)diagonal specific data).
     double shear_min, shear_max, shear_mean, normal_min, normal_max, normal_mean;
     getGreensStats(sim, shear_min, shear_max, shear_mean, normal_min, normal_max, normal_mean);
     sim->console() << "# Greens Shear:\n max: " << shear_max << "\n min: " << shear_min << "\n mean: " << shear_mean << std::endl << std::endl;
@@ -254,17 +254,17 @@ void GreensInit::getGreensStats(Simulation *sim, double &shear_min, double &shea
 };
 
 void GreensInit::getGreensDiagStats(Simulation *sim, double &shear_diag_min, double &shear_diag_max, double &shear_diag_mean, double &normal_diag_min, double &normal_diag_max, double &normal_diag_mean, double &shear_offdiag_min, double &shear_offdiag_max, double &shear_offdiag_mean, double &normal_offdiag_min, double &normal_offdiag_max, double &normal_offdiag_mean) {
-	// gather max/min values for greens functions (which we may have defined in the parameter file).
-	// note: we (see ProgressMonitor.cpp/h; we could use BlockVal declarations (is there a GreensVal object? we could create one) to
-	// combine the block_id, or in this case the block_id pair, with the gr_values.
-	// for (off) diagonal elements
-	//
-	int         lid;
+    // gather max/min values for greens functions (which we may have defined in the parameter file).
+    // note: we (see ProgressMonitor.cpp/h; we could use BlockVal declarations (is there a GreensVal object? we could create one) to
+    // combine the block_id, or in this case the block_id pair, with the gr_values.
+    // for (off) diagonal elements
+    //
+    int         lid;
     BlockID     gid;
     double      shear_diag_min_l, shear_diag_max_l, normal_diag_min_l, normal_diag_max_l;   // local-node copies...
     double      shear_diag_sum, normal_diag_sum;
     //
-    double      shear_offdiag_min_l, shear_offdiag_max_l, normal_offdiag_min_l, normal_offdiag_max_l;	// local-node copies
+    double      shear_offdiag_min_l, shear_offdiag_max_l, normal_offdiag_min_l, normal_offdiag_max_l;   // local-node copies
     double      shear_offdiag_sum, normal_offdiag_sum;
     //
     double      cur_shear, cur_normal;
@@ -276,88 +276,110 @@ void GreensInit::getGreensDiagStats(Simulation *sim, double &shear_diag_min, dou
     //
     shear_diag_sum = normal_diag_sum = 0;
     shear_offdiag_sum = normal_offdiag_sum = 0;
-    
+
     //min_val.block_id = max_val.block_id = sum_val.block_id = UNDEFINED_ELEMENT_ID;
 
     // Get the minimum, maximum and sum CFF values on this node
     for (lid=0; lid<sim->numLocalBlocks(); ++lid) {
         gid = sim->getGlobalBID(lid);
+
         //
         // now, loop over the sim events to get greens-pair values:
         for (nt=sim->begin(); nt!=sim->end(); ++nt) {
             //stress_drop += (nt->slip_rate()/norm_velocity)*sim->getGreenShear(gid, nt->getBlockID());
             cur_shear  = sim->getGreenShear(gid, nt->getBlockID());
             cur_normal = sim->getGreenNormal(gid, nt->getBlockID());
+
             //
             if (gid==nt->getBlockID()) {
-            	// diagonal elements:
-            	//printf("diag: %d, %d:: %f/%f\n", gid, nt->getBlockID(), cur_shear, cur_normal);
-	            shear_diag_min_l = std::min(shear_diag_min_l, cur_shear);
-	            shear_diag_max_l = std::max(shear_diag_max_l, cur_shear);
-	            shear_diag_sum += cur_shear;
-	            //
-	            normal_diag_min_l = std::min(normal_diag_min_l, cur_normal);
-	            normal_diag_max_l = std::max(normal_diag_max_l, cur_normal);
-	            normal_diag_sum += cur_normal;
+                // diagonal elements:
+                //printf("diag: %d, %d:: %f/%f\n", gid, nt->getBlockID(), cur_shear, cur_normal);
+                shear_diag_min_l = std::min(shear_diag_min_l, cur_shear);
+                shear_diag_max_l = std::max(shear_diag_max_l, cur_shear);
+                shear_diag_sum += cur_shear;
+                //
+                normal_diag_min_l = std::min(normal_diag_min_l, cur_normal);
+                normal_diag_max_l = std::max(normal_diag_max_l, cur_normal);
+                normal_diag_sum += cur_normal;
             }
             //
-            else { 
-            	//if (gid!=nt->getBlockID()) {
-            	// off-diagonal elements:
-    	        //printf("off-diag: %d, %d:: %f/%f\n", gid, nt->getBlockID(), cur_shear, cur_normal);
-    	        shear_offdiag_min_l = std::min(shear_offdiag_min_l, cur_shear);
-    	        shear_offdiag_max_l = std::max(shear_offdiag_max_l, cur_shear);
-    	        shear_offdiag_sum += cur_shear;
-    	        //
-    	        normal_offdiag_min_l = std::min(normal_offdiag_min_l, cur_normal);
-    	        normal_offdiag_max_l = std::max(normal_offdiag_max_l, cur_normal);
-    	        normal_offdiag_sum += cur_normal;
-    	    };
+            else {
+                //if (gid!=nt->getBlockID()) {
+                // off-diagonal elements:
+                //printf("off-diag: %d, %d:: %f/%f\n", gid, nt->getBlockID(), cur_shear, cur_normal);
+                shear_offdiag_min_l = std::min(shear_offdiag_min_l, cur_shear);
+                shear_offdiag_max_l = std::max(shear_offdiag_max_l, cur_shear);
+                shear_offdiag_sum += cur_shear;
+                //
+                normal_offdiag_min_l = std::min(normal_offdiag_min_l, cur_normal);
+                normal_offdiag_max_l = std::max(normal_offdiag_max_l, cur_normal);
+                normal_offdiag_sum += cur_normal;
+            };
         };
     };
-    
+
 
     // Reduce to the min/avg/max over all nodes
-    #ifdef MPI_C_FOUND
-    int mpi_return=0;	// holder variable; mpi_reduce returns an int. maybe we'll have on efor each?
+#ifdef MPI_C_FOUND
+    int mpi_return=0;   // holder variable; mpi_reduce returns an int. maybe we'll have on efor each?
+
     // construct MPI_reduce calls here:
     mpi_return = MPI_Allreduce(&shear_diag_min_l, &shear_diag_min, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+
     mpi_return = MPI_Allreduce(&shear_diag_max_l, &shear_diag_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
     mpi_return = MPI_Allreduce(&shear_diag_sum, &shear_diag_mean,  1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-    
+
     mpi_return = MPI_Allreduce(&shear_offdiag_min_l, &shear_offdiag_min, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+
     mpi_return = MPI_Allreduce(&shear_offdiag_max_l, &shear_offdiag_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
     mpi_return = MPI_Allreduce(&shear_offdiag_sum, &shear_offdiag_mean,  1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-    
+
     mpi_return = MPI_Allreduce(&normal_diag_min_l, &normal_diag_min, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+
     mpi_return = MPI_Allreduce(&normal_diag_max_l, &normal_diag_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
     mpi_return = MPI_Allreduce(&normal_diag_sum, &normal_diag_mean,  1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-    
+
     mpi_return = MPI_Allreduce(&normal_offdiag_min_l, &normal_offdiag_min, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+
     mpi_return = MPI_Allreduce(&normal_offdiag_max_l, &normal_offdiag_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
     mpi_return = MPI_Allreduce(&normal_offdiag_sum, &normal_offdiag_mean,  1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-        
-    #else
+
+#else
     shear_diag_min = shear_diag_min_l;
+
     shear_diag_max = shear_diag_max_l;
+
     shear_diag_mean = shear_diag_sum;
-    
+
     shear_offdiag_min = shear_offdiag_min_l;
+
     shear_offdiag_max = shear_offdiag_max_l;
+
     shear_offdiag_mean = shear_offdiag_sum;
 
     normal_diag_min = normal_diag_min_l;
+
     normal_diag_max = normal_diag_max_l;
+
     normal_diag_mean = normal_diag_sum;
-    
+
     normal_offdiag_min = normal_offdiag_min_l;
+
     normal_offdiag_max = normal_offdiag_max_l;
+
     normal_offdiag_mean = normal_offdiag_sum;
-    #endif
+
+#endif
     shear_diag_mean  /= sim->numGlobalBlocks();
+
     normal_diag_mean /= sim->numGlobalBlocks();
-    
+
     shear_offdiag_mean  /= sim->numGlobalBlocks();
+
     normal_offdiag_mean /= sim->numGlobalBlocks();
 };
 

--- a/src/simulation/GreensInit.h
+++ b/src/simulation/GreensInit.h
@@ -39,7 +39,7 @@ class GreensInit : public SimPlugin {
         // yoder: also get some greens stats:
         void getGreensStats(Simulation *sim, double &shear_min, double &shear_max, double &shear_mean, double &normal_min, double &normal_max, double &normal_mean);
         void getGreensDiagStats(Simulation *sim, double &shear_diag_min, double &shear_diag_max, double &shear_diag_mean, double &normal_diag_min, double &normal_diag_max, double &normal_diag_mean, double &shear_offdiag_min, double &shear_offdiag_max, double &shear_offdiag_mean, double &normal_offdiag_min, double &normal_offdiag_max, double &normal_offdiag_mean);
-        
+
 };
 
 #endif

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -489,7 +489,6 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             sim->setNormalStress(gid, sim->getRhogd(gid));
             //sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 :sim->getSlipDeficit(gid) )); // ... also check for nan values
             sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
-            //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
 
             ////////// Schultz:
             // We need to ensure our slip economics books are balanced. I suspect we need here
@@ -545,11 +544,11 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             sim->setNormalStress(gid, sim->getRhogd(gid));
             //
             // if this is a current/original failure, then 0 else...
-            //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
+            sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
             //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 : sim->getSlipDeficit(gid)));
             
             //////// Schultz: try setting updatefield 0 for newly failed elements this sweep
-            sim->setUpdateField(gid, ((sim->getFailed(gid) && global_failed_elements.count(gid) == 0) ? 0 : sim->getSlipDeficit(gid)));            
+            //sim->setUpdateField(gid, ((sim->getFailed(gid) && global_failed_elements.count(gid) == 0) ? 0 : sim->getSlipDeficit(gid)));            
             // We need to ensure our slip economics books are balanced. I suspect we need here
             // instead: sim->setUpdateField(gid, sim->getSlipDeficit(gid) ). Update the stresses using
             // the current slip of all elements, or else we throw away the slip information from failed elements.

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -64,15 +64,6 @@ void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &swe
             //
 
             ///// Schultz:
-            // Avoid the scenario that CFF is slightly changed due to other failed blocks,
-            //  so that we never satisfy the condition if (!stress_drop). Must check this
-            //  in the future.
-
-            // calculate the drop in stress from the failure
-            //stress_drop = sim->getCFF0(gid) - sim->getCFF(gid);
-            //if (!stress_drop) stress_drop = sim->getStressDrop(gid) - sim->getCFF(gid);
-
-            ////// Schultz
             stress_drop = sim->getStressDrop(gid) - sim->getCFF(gid);
 
             // Slip is in m
@@ -80,8 +71,9 @@ void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &swe
 
             ////// Schultz:
             // The only  reason for slip < 0 is stress_drop > 0, which occurs when CFF << getStressDrop(gid).
-            // So if stress_drop > 0, the element shouldn't be slipping.
-            if (slip < 0) slip = 0;
+            // So if stress_drop > 0, the element shouldn't be slipping. We must allow it to happen if it does.
+            // Perhaps the system needs this due to element loading thru interactions.
+            //if (slip < 0) slip = 0;
 
             // Record how much the block slipped in this sweep and initial stresses
             sweeps.setSlipAndArea(sweep_num,

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -552,12 +552,15 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             //
             // if this is a current/original failure, then 0 else...
             //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
+            //////// Schultz: trying this
+            sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
+            
             //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 : sim->getSlipDeficit(gid)));
             ////////// Schultz:
             // We need to ensure our slip economics books are balanced. I suspect we need here
             // instead: sim->setUpdateField(gid, sim->getSlipDeficit(gid) ). Update the stresses using
             // the current slip of all elements, or else we throw away the slip information from failed elements.
-            sim->setUpdateField(gid, sim->getSlipDeficit(gid));
+            //sim->setUpdateField(gid, sim->getSlipDeficit(gid));
         }
 
         //

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -79,9 +79,9 @@ void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &swe
             slip = (stress_drop/sim->getSelfStresses(gid));
 
             ////// Schultz:
-            // Relaxing the restriction on negative slip for now. We will investigate the cause/effect
-            // of negative slips in the future.
-            //if (slip < 0) slip = 0;
+            // The only reason for slip < 0 is stress_drop > 0, which occurs when CFF << getStressDrop(gid).
+            // So if stress_drop > 0, the element shouldn't be slipping.
+            if (slip < 0) slip = 0;
 
             // Record how much the block slipped in this sweep and initial stresses
             sweeps.setSlipAndArea(sweep_num,

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -69,9 +69,11 @@ void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &swe
             //  in the future.
             
             // calculate the drop in stress from the failure
-            stress_drop = sim->getCFF0(gid) - sim->getCFF(gid);
+            //stress_drop = sim->getCFF0(gid) - sim->getCFF(gid);
+            //if (!stress_drop) stress_drop = sim->getStressDrop(gid) - sim->getCFF(gid);
             
-            if (!stress_drop) stress_drop = sim->getStressDrop(gid) - sim->getCFF(gid);
+            ////// Schultz
+            stress_drop = sim->getStressDrop(gid) - sim->getCFF(gid);
             
             // Slip is in m
             slip = (stress_drop/sim->getSelfStresses(gid));
@@ -197,7 +199,11 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
         //b[i] = sim->getCFF(*it)+sim->getFriction(*it)*sim->getRhogd(*it);
         ////// Schultz:
         // Need to incorporate stress drop here somehow, we need secondary
-        // rupture physics to be same as primary.
+        // rupture physics to be same as primary. This incorporates the physics that
+        // for static failure (CFF=0) the amount of stress to release is the stress drop.
+        // For dynamic failure this amount of stress is reduced by however much stress is still
+        // needed to reach static failure. Or if the element has accumulated a ton of stress (CFF>0)
+        // then this adds that extra amount to the stress needed to be released.
         b[i] = sim->getStressDrop(*it) - sim->getCFF(*it);
     }
 

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -79,7 +79,7 @@ void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &swe
             slip = (stress_drop/sim->getSelfStresses(gid));
 
             ////// Schultz:
-            // The only reason for slip < 0 is stress_drop > 0, which occurs when CFF << getStressDrop(gid).
+            // The only  reason for slip < 0 is stress_drop > 0, which occurs when CFF << getStressDrop(gid).
             // So if stress_drop > 0, the element shouldn't be slipping.
             if (slip < 0) slip = 0;
 
@@ -551,7 +551,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             sim->setNormalStress(gid, sim->getRhogd(gid));
             //
             // if this is a current/original failure, then 0 else...
-            sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
+            //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
             //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 : sim->getSlipDeficit(gid)));
             
             //////// Schultz: try setting updatefield 0 for newly failed elements this sweep
@@ -559,7 +559,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             // We need to ensure our slip economics books are balanced. I suspect we need here
             // instead: sim->setUpdateField(gid, sim->getSlipDeficit(gid) ). Update the stresses using
             // the current slip of all elements, or else we throw away the slip information from failed elements.
-            //sim->setUpdateField(gid, sim->getSlipDeficit(gid));
+            sim->setUpdateField(gid, sim->getSlipDeficit(gid));
         }
 
         //
@@ -629,6 +629,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
         for (quakelib::ModelSweeps::iterator s_it=event_sweeps.begin(); s_it!=event_sweeps.end(); ++s_it, ++event_sweeps_pos) {
             //
             // yoder: as per request by KS, change isnan() --> std::isnan(); isnan() appears to throw an error on some platforms.
+            // Eric: Probably don't need this if check
             if (std::isnan(s_it->_shear_final) and std::isnan(s_it->_normal_final)) {
                 // note: the stress entries are initialized with nan values, but if there are cases where non nan values need to be updated,
                 // this logic should be revisited.

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -488,7 +488,8 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             sim->setShearStress(gid, 0.0);
             sim->setNormalStress(gid, sim->getRhogd(gid));
             //sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 :sim->getSlipDeficit(gid) )); // ... also check for nan values
-            sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
+            //sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
+            sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
 
             ////////// Schultz:
             // We need to ensure our slip economics books are balanced. I suspect we need here
@@ -551,9 +552,9 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             sim->setNormalStress(gid, sim->getRhogd(gid));
             //
             // if this is a current/original failure, then 0 else...
-            //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
+            sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
             //////// Schultz: trying this
-            sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
+            //sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
             
             //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 : sim->getSlipDeficit(gid)));
             ////////// Schultz:

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -67,14 +67,14 @@ void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &swe
             // Avoid the scenario that CFF is slightly changed due to other failed blocks,
             //  so that we never satisfy the condition if (!stress_drop). Must check this
             //  in the future.
-            
+
             // calculate the drop in stress from the failure
             //stress_drop = sim->getCFF0(gid) - sim->getCFF(gid);
             //if (!stress_drop) stress_drop = sim->getStressDrop(gid) - sim->getCFF(gid);
-            
+
             ////// Schultz
             stress_drop = sim->getStressDrop(gid) - sim->getCFF(gid);
-            
+
             // Slip is in m
             slip = (stress_drop/sim->getSelfStresses(gid));
 
@@ -397,7 +397,7 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
         ////// Schultz:
         // We may be destabilizing the system here if the solution includes negative slipped elements.
         // We cannot solve the whole system then throw out a few elements.
-        
+
         ////// Schultz:
         // Relaxing the restriction on negative slip for now. We will investigate the cause/effect
         // of negative slips in the future.
@@ -553,9 +553,9 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             // if this is a current/original failure, then 0 else...
             //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
             //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 : sim->getSlipDeficit(gid)));
-            
+
             //////// Schultz: try setting updatefield 0 for newly failed elements this sweep
-            //sim->setUpdateField(gid, ((sim->getFailed(gid) && global_failed_elements.count(gid) == 0) ? 0 : sim->getSlipDeficit(gid)));            
+            //sim->setUpdateField(gid, ((sim->getFailed(gid) && global_failed_elements.count(gid) == 0) ? 0 : sim->getSlipDeficit(gid)));
             // We need to ensure our slip economics books are balanced. I suspect we need here
             // instead: sim->setUpdateField(gid, sim->getSlipDeficit(gid) ). Update the stresses using
             // the current slip of all elements, or else we throw away the slip information from failed elements.

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -194,10 +194,11 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
             }
         }
 
-        b[i] = sim->getCFF(*it)+sim->getFriction(*it)*sim->getRhogd(*it);
+        //b[i] = sim->getCFF(*it)+sim->getFriction(*it)*sim->getRhogd(*it);
         ////// Schultz:
         // Need to incorporate stress drop here somehow, we need secondary
         // rupture physics to be same as primary.
+        b[i] = sim->getStressDrop(*it) - sim->getCFF(*it);
     }
 
     //

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -76,7 +76,10 @@ void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &swe
             // Slip is in m
             slip = (stress_drop/sim->getSelfStresses(gid));
 
-            if (slip < 0) slip = 0;
+            ////// Schultz:
+            // Relaxing the restriction on negative slip for now. We will investigate the cause/effect
+            // of negative slips in the future.
+            //if (slip < 0) slip = 0;
 
             // Record how much the block slipped in this sweep and initial stresses
             sweeps.setSlipAndArea(sweep_num,
@@ -387,20 +390,24 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
         ////// Schultz:
         // We may be destabilizing the system here if the solution includes negative slipped elements.
         // We cannot solve the whole system then throw out a few elements.
-        if (slip > 0) {
-            // Record how much the block slipped in this sweep and initial stresse
-            sweeps.setSlipAndArea(sweep_num,
-                                  *it,
-                                  slip,
-                                  block.area(),
-                                  block.lame_mu());
-            sweeps.setInitStresses(sweep_num,
-                                   *it,
-                                   sim->getShearStress(*it),
-                                   sim->getNormalStress(*it));
-            //
-            sim->setSlipDeficit(*it, sim->getSlipDeficit(*it)+slip);
-        }
+        
+        ////// Schultz:
+        // Relaxing the restriction on negative slip for now. We will investigate the cause/effect
+        // of negative slips in the future.
+        //if (slip > 0) {
+        // Record how much the block slipped in this sweep and initial stresse
+        sweeps.setSlipAndArea(sweep_num,
+                              *it,
+                              slip,
+                              block.area(),
+                              block.lame_mu());
+        sweeps.setInitStresses(sweep_num,
+                               *it,
+                               sim->getShearStress(*it),
+                               sim->getNormalStress(*it));
+        //
+        sim->setSlipDeficit(*it, sim->getSlipDeficit(*it)+slip);
+        //}
     }
 
     //

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -487,13 +487,14 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             BlockID gid = it->getBlockID();
             sim->setShearStress(gid, 0.0);
             sim->setNormalStress(gid, sim->getRhogd(gid));
-            sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 :sim->getSlipDeficit(gid) )); // ... also check for nan values
+            //sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 :sim->getSlipDeficit(gid) )); // ... also check for nan values
             //sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
 
             ////////// Schultz:
             // We need to ensure our slip economics books are balanced. I suspect we need here
             // instead: sim->setUpdateField(gid, sim->getSlipDeficit(gid) ). Update the stresses using
             // the current slip of all elements, or else we throw away the slip information from primary ruptures.
+            sim->setUpdateField(gid, sim->getSlipDeficit(gid));
         }
 
         // Distribute the update field values to other processors
@@ -507,7 +508,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             BlockID gid = it->getBlockID();
 
             // Add block neighbors if the block has slipped
-            if (sim->getUpdateField(gid) == 0) {
+            if (sim->getFailed(gid)) {
                 nbr_start_end = sim->getNeighbors(gid);
 
                 for (nit=nbr_start_end.first; nit!=nbr_start_end.second; ++nit) {
@@ -551,11 +552,12 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             //
             // if this is a current/original failure, then 0 else...
             //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : sim->getSlipDeficit(gid)));
-            sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 : sim->getSlipDeficit(gid)));
+            //sim->setUpdateField(gid, (global_failed_elements.count(gid)>0 ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 : sim->getSlipDeficit(gid)));
             ////////// Schultz:
             // We need to ensure our slip economics books are balanced. I suspect we need here
             // instead: sim->setUpdateField(gid, sim->getSlipDeficit(gid) ). Update the stresses using
             // the current slip of all elements, or else we throw away the slip information from failed elements.
+            sim->setUpdateField(gid, sim->getSlipDeficit(gid));
         }
 
         //

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -488,13 +488,13 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             sim->setShearStress(gid, 0.0);
             sim->setNormalStress(gid, sim->getRhogd(gid));
             //sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : std::isnan(sim->getSlipDeficit(gid)) ? 0 :sim->getSlipDeficit(gid) )); // ... also check for nan values
-            //sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
+            sim->setUpdateField(gid, (sim->getFailed(gid) ? 0 : sim->getSlipDeficit(gid)));
 
             ////////// Schultz:
             // We need to ensure our slip economics books are balanced. I suspect we need here
             // instead: sim->setUpdateField(gid, sim->getSlipDeficit(gid) ). Update the stresses using
             // the current slip of all elements, or else we throw away the slip information from primary ruptures.
-            sim->setUpdateField(gid, sim->getSlipDeficit(gid));
+            //sim->setUpdateField(gid, sim->getSlipDeficit(gid));
         }
 
         // Distribute the update field values to other processors

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -81,6 +81,9 @@ void UpdateBlockStress::init(SimFramework *_sim) {
             stress_drop *= sim->getBlock(gid).max_slip();
             /////// Schultz: All stress drops must be negative
             if (stress_drop > 0) stress_drop = -1.0*fabs(stress_drop);
+            
+            /////// Schultz: Hack #2, multiply the stress drops by 2.7 to get closer to the prescribed VC stress drop values
+            stress_drop *= 2.7;
             sim->setStressDrop(gid, stress_drop);
             
         } else {
@@ -131,6 +134,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
 
     // Compute initial stress on all blocks
     stressRecompute();
+
 }
 
 /*!

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -27,22 +27,55 @@
 void UpdateBlockStress::init(SimFramework *_sim) {
     BlockList::iterator nt;
     BlockID             gid;
+    SectionID           sid;
     int                 lid;
     double              stress_drop, norm_velocity;
     double rho = 2700.0;      // density of rock in kg m^-3
     double g = 9.81;           // force of gravity in m s^-2
     double depth = 0.0;         //
     double mean_slip_rate = 0.0;
+    double char_magnitude, char_slip, fault_length, fault_area, fault_width, nu, R;
+    std::map<SectionID, double> section_lengths;
+    std::map<SectionID, double> section_areas;
+    std::map<SectionID, double>::iterator sit;
 
     sim = static_cast<Simulation *>(_sim);
     tmpBuffer = new double[sim->numGlobalBlocks()];
     
+    // Determine section lengths and add up the areas
+    for (nt=sim->begin(); nt!=sim->end(); ++nt) {
+        sid = nt->getSectionID();
+        
+        if (section_lengths.count(sid)) {
+            sit = section_lengths.find(sid);
+            // Replace the current max length with this element's distance along strike if it's larger
+            sit->second = std::max(sit->second, nt->max_das());
+            
+        } else {
+            // If it's not already in here, add this section
+            section_lengths.insert(std::make_pair(sid, nt->max_das()));
+        }
+        
+        if (section_areas.count(sid)) {
+            sit = section_areas.find(sid);
+            // Add the current element's area to the section's total
+            sit->second += nt->area();
+            
+        } else {
+            // If it's not already in here, add this section
+            section_areas.insert(std::make_pair(sid, nt->area()));
+        }
+        
+    }
+    
+    /*
     /////// Schultz: First we compute the mean slip rate to avoid NaN's
     for (nt=sim->begin(); nt!=sim->end(); ++nt) {
         mean_slip_rate += nt->slip_rate();
     }
     // Normalize by number of blocks
     mean_slip_rate /= sim->numGlobalBlocks();
+    */
 
     // All processes need the friction values for all blocks, so we set rhogd here
     // and transfer stress drop values between nodes later
@@ -70,6 +103,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
             //       we need to have some minimum or mean normalization constant to
             //       handle zero slip rates that lead to stress_drop = NaN.
             
+            /* Eric's stress drop method
             // Now compute weighted stress drops from slip rates and shear interactions
             stress_drop = 0;
             norm_velocity = sim->getBlock(gid).slip_rate();
@@ -77,7 +111,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
             for (nt=sim->begin(); nt!=sim->end(); ++nt) {
                 stress_drop += ((nt->slip_rate() + mean_slip_rate)/(norm_velocity + mean_slip_rate))*sim->getGreenShear(gid, nt->getBlockID());
             }
-
+            
             stress_drop *= sim->getBlock(gid).max_slip();
             /////// Schultz: All stress drops must be negative
             if (stress_drop > 0) stress_drop = -1.0*fabs(stress_drop);
@@ -85,6 +119,28 @@ void UpdateBlockStress::init(SimFramework *_sim) {
             /////// Schultz: Hack #2, multiply the stress drops by 5.0 to get closer to the prescribed VC stress drop values
             // TODO: Make this a parameter
             stress_drop *= 5.0;
+            */
+            
+            ///// Schultz stress drop method
+            // Get the section id, sid
+            sid = sim->getBlock(gid).getSectionID();
+            // Get fault area and length (we will compute the width)
+            sit = section_areas.find(sid);
+            fault_area = sit->second;
+            sit = section_lengths.find(sid);
+            fault_length = sit->second;
+            fault_width = fault_area/fault_length;
+            
+            // Use Wells & Coppersmith scaling to find the characteristic magnitude and slip given the fault geometry
+            char_magnitude = 4.07+0.98*log10(fault_area*1e-6) + sim->stressDropFactor();
+            char_slip = pow(10, (3.0/2.0)*(char_magnitude+10.7))/(1e7*sim->getBlock(gid).lame_mu()*fault_area);
+            
+            // Compute stress drop from geometry and expected slip/mag
+            nu = 0.5*sim->getBlock(gid).lame_lambda()/(sim->getBlock(gid).lame_mu() + sim->getBlock(gid).lame_lambda());
+            R  = sqrt(fault_width*fault_width + fault_length*fault_length);
+            
+            stress_drop = -2*sim->getBlock(gid).lame_mu()*char_slip*( (1-nu)*fault_width/fault_length + fault_length/fault_width )/( (1-nu)*M_PI*R ) ;
+
             sim->setStressDrop(gid, stress_drop);
             
         } else {
@@ -135,6 +191,11 @@ void UpdateBlockStress::init(SimFramework *_sim) {
 
     // Compute initial stress on all blocks
     stressRecompute();
+    
+    // printing 
+    for (nt=sim->begin(); nt!=sim->end(); ++nt) {
+        std::cout << nt->stress_drop() << std::endl;
+    }
 
 }
 

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -139,7 +139,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
             nu = 0.5*sim->getBlock(gid).lame_lambda()/(sim->getBlock(gid).lame_mu() + sim->getBlock(gid).lame_lambda());
             R  = sqrt(fault_width*fault_width + fault_length*fault_length);
 
-            stress_drop = -2*sim->getBlock(gid).lame_mu()*char_slip*( (1-nu)*fault_width/fault_length + fault_length/fault_width )/( (1-nu)*M_PI*R ) ;
+            stress_drop = -2*sim->getBlock(gid).lame_mu()*char_slip*( (1-nu)*fault_length/fault_width + fault_width/fault_length )/( (1-nu)*M_PI*R ) ;
 
             sim->setStressDrop(gid, stress_drop);
 

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -78,7 +78,11 @@ void UpdateBlockStress::init(SimFramework *_sim) {
                 stress_drop += ((nt->slip_rate() + mean_slip_rate)/(norm_velocity + mean_slip_rate))*sim->getGreenShear(gid, nt->getBlockID());
             }
 
-            sim->setStressDrop(gid, sim->getBlock(gid).max_slip()*stress_drop);
+            stress_drop *= sim->getBlock(gid).max_slip();
+            /////// Schultz: All stress drops must be negative
+            if (stress_drop > 0) stress_drop = -1.0*fabs(stress_drop);
+            sim->setStressDrop(gid, stress_drop);
+            
         } else {
             sim->setStressDrop(gid, sim->getBlock(gid).stress_drop());
         }

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -82,8 +82,9 @@ void UpdateBlockStress::init(SimFramework *_sim) {
             /////// Schultz: All stress drops must be negative
             if (stress_drop > 0) stress_drop = -1.0*fabs(stress_drop);
             
-            /////// Schultz: Hack #2, multiply the stress drops by 2.7 to get closer to the prescribed VC stress drop values
-            stress_drop *= 2.7;
+            /////// Schultz: Hack #2, multiply the stress drops by 5.0 to get closer to the prescribed VC stress drop values
+            // TODO: Make this a parameter
+            stress_drop *= 5.0;
             sim->setStressDrop(gid, stress_drop);
             
         } else {


### PR DESCRIPTION
Current status: Scaling for EQs above M~6 is acceptable. For small events we still seem to be adding too many elements, which forces smaller and smaller slips per element.

Change List:
--Stress drops are now in Sachs' style. stress_drop = model_stress_drop - CFF, this is true for primary and secondary failures, it reflects how much stress is currently available to use for slipping

--Stress drops are forced to be negative, and values just multiplied to get closer to the values used in the VC runs. Further improvements for computed stress drops are under way now

--Secondary failures (matrix solution for slips) are allowed to have negative slip during a sweep. We cannot throw out these solutions to the whole system if we want it to be stable.

--Fixed which slips are updated for CFF (stress) recomputing post-secondary failures. We now update the stress field due to slip on all elements in the sim.

--Fixed the isFailed check for adding the neighbors of failed elements to the loose_elements list (allowed to dynamically fail).

I apologize for the spaghetti-ed commits, it was a hectic couple of weeks getting this together. @eheien and @markyoder feedback is welcome, though I think we've ironed out the details in person