### PR TITLE
Stress I/O and PyVQ hdf5 event file combining

### DIFF
--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -271,9 +271,9 @@ class TriggerSectionFilter:
         return False
 
     def plot_str(self):
-        label_stre = "  triggerSections"
-        for sec in section_list:
-            label_str += "-"+str(sec)
+        label_str = "  triggerSections"
+        for sec in self._section_list:
+            label_str += "-"+geometry.model.section(sec).name()
         return label_str
 
         
@@ -1815,7 +1815,9 @@ class BasePlotter:
         elif plot_type == "line":
             ax.plot(x_data, y_data, color='g')
         elif plot_type == "hist":
-            ax.hist(x_data, bins=100)
+            if len(x_data) > 200: BINS=1000
+            else: BINS=100
+            ax.hist(x_data, bins=BINS)
         plt.gca().get_xaxis().get_major_formatter().set_useOffset(False)
         plt.savefig(filename,dpi=100)
         sys.stdout.write("Plot saved: {}\n".format(filename))
@@ -2580,7 +2582,7 @@ if __name__ == "__main__":
     if args.plot_recurrence:
         times = events.interevent_times()
         filename = SaveFile().event_plot(args.event_file, "recurrence", args.min_magnitude, args.min_year, args.max_year)
-        BasePlotter().create_plot("hist", False, times, None, "Recurrence Times", "interevent time [years]", "", filename)
+        BasePlotter().create_plot("hist", False, times, None, events.plot_str(), "interevent time [years]", "", filename)
 
     if args.field_plot:
         type = args.field_type.lower()

--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -216,10 +216,11 @@ class EventNumFilter:
         return (event.getEventNumber() >= self._min_event_num and event.getEventNumber() <= self._max_event_num)
 
     def plot_str(self):
-        label_str = ""
+        label_str = "  "
 # TODO: change to <= character
         if self._min_event_num != -sys.maxint: label_str += str(self._min_event_num)+"<"
-        if self._max_event_num != sys.maxint: label_str += "event num<"+str(self._max_event_num)
+        label_str += "event num"
+        if self._max_event_num != sys.maxint: label_str += "<"+str(self._max_event_num)
         return label_str
 
 class SectionFilter:
@@ -2483,7 +2484,7 @@ if __name__ == "__main__":
         event_filters.append(AreaFilter(min_area=args.min_area, max_area=args.max_area))
 
     if args.min_event_num or args.max_event_num:
-        event_filters.append(EventNumFilter(min_mag=args.min_event_num, max_mag=args.max_event_num))
+        event_filters.append(EventNumFilter(min_event_num=args.min_event_num, max_event_num=args.max_event_num))
 
     if args.use_sections:
         if not args.model_file: raise "Must specify --model_file for --use_sections to work."

--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -223,6 +223,22 @@ class EventNumFilter:
         if self._max_event_num != sys.maxint: label_str += "<"+str(self._max_event_num)
         return label_str
 
+class NumElementsFilter:
+    def __init__(self, min_num_elements=None, max_num_elements=None):
+        self._min_num_elements = min_num_elements if min_num_elements is not None else 0
+        self._max_num_elements = max_num_elements if max_num_elements is not None else sys.maxint
+    
+    def test_event(self, event):
+        return (len(event.getInvolvedElements()) >= self._min_num_elements and len(event.getInvolvedElements()) <= self._max_num_elements)
+    
+    def plot_str(self):
+        label_str = "  "
+        # TODO: change to <= character
+        if self._min_num_elements != 0: label_str += str(self._min_num_elements)+"<"
+        label_str += "num elements"
+        if self._max_num_elements != sys.maxint: label_str += "<"+str(self._max_num_elements)
+        return label_str
+
 class SectionFilter:
     def __init__(self, geometry, section_list):
         self._section_list = section_list
@@ -2301,6 +2317,10 @@ if __name__ == "__main__":
             help="Minimum event number of events to process.")
     parser.add_argument('--max_event_num', type=float, required=False,
             help="Maximum event number of events to process.")
+    parser.add_argument('--min_num_elements', type=float, required=False,
+                        help="Minimum number of elements involved in an event")
+    parser.add_argument('--max_num_elements', type=float, required=False,
+                        help="Maximum number of elements involved in an event")
     parser.add_argument('--use_sections', type=int, nargs='+', required=False,
             help="List of model sections to use (all sections used if unspecified).")
     parser.add_argument('--use_trigger_sections', type=int, nargs='+', required=False,
@@ -2468,6 +2488,9 @@ if __name__ == "__main__":
     event_filters = []
     if args.min_magnitude or args.max_magnitude:
         event_filters.append(MagFilter(min_mag=args.min_magnitude, max_mag=args.max_magnitude))
+
+    if args.min_num_elements or args.max_num_elements:
+        event_filters.append(NumElementsFilter(min_num_elements=args.min_num_elements, max_num_elements=args.max_num_elements))
 
     if args.min_year or args.max_year:
         event_filters.append(YearFilter(min_year=args.min_year, max_year=args.max_year))

--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -1814,6 +1814,8 @@ class BasePlotter:
             ax.scatter(x_data, y_data, color='g')
         elif plot_type == "line":
             ax.plot(x_data, y_data, color='g')
+        elif plot_type == "hist":
+            ax.hist(x_data, bins=100)
         plt.gca().get_xaxis().get_major_formatter().set_useOffset(False)
         plt.savefig(filename,dpi=100)
         sys.stdout.write("Plot saved: {}\n".format(filename))
@@ -2339,6 +2341,8 @@ if __name__ == "__main__":
             help="Plot Wells and Coppersmith 1994 scaling relations.")
     parser.add_argument('--leonard', required=False, action='store_true',
             help="Plot Leonard 2010 scaling relations.")
+    parser.add_argument('--plot_recurrence', required=False, action='store_true',
+            help="Plot distribution of recurrence intervals.")
 
     # Probability plotting arguments
     parser.add_argument('--plot_prob_vs_t', required=False, action='store_true',
@@ -2573,6 +2577,11 @@ if __name__ == "__main__":
     if args.plot_waiting_times:
         filename = SaveFile().event_plot(args.event_file, "waiting_times", args.min_magnitude, args.min_year, args.max_year)
         ProbabilityPlot().plot_dt_vs_t0(events, filename)
+    if args.plot_recurrence:
+        times = events.interevent_times()
+        filename = SaveFile().event_plot(args.event_file, "recurrence", args.min_magnitude, args.min_year, args.max_year)
+        BasePlotter().create_plot("hist", False, times, None, "Recurrence Times", "interevent time [years]", "", filename)
+
     if args.field_plot:
         type = args.field_type.lower()
         if args.colorbar_max: cbar_max = args.colorbar_max

--- a/doc/vq.tex
+++ b/doc/vq.tex
@@ -1617,6 +1617,36 @@ To implement these bounds for the shear stress Greens functions, in your simulat
 	
 
 
+
+\subsection{Periodically Saving the Simulation State}
+The Virtual Quake simulation can crash mid-simulation for a number of reasons, and while we do not anticipate your simulation to crash, it does happen. To prevent the loss of simulation data, and to avoid the situation of a simulation crashing 50,000 years in, leaving you to start your large simulation from the beginning, we have the ability to output the state of simulation. 
+
+In order to save the simulation state to an HDF5 file, for example, after every 10,000 earthquakes, simply add the following to your simulation parameter file:
+
+\begin{verbatim}
+	sim.file.output_stress  	   	      = file_to_save_sim_state.h5
+	sim.file.output_stress_type  	      = hdf5
+	sim.file.output_stress_num_events = 10000
+\end{verbatim}
+
+If you want to start a simulation after the last checkpoint was written for the previous simulation, simply run a new simulation with the following parameters:
+
+\begin{verbatim}
+	sim.file.input_stress  	   	      = file_to_save_sim_state.h5
+	sim.file.input_stress_type        = hdf5
+\end{verbatim}
+
+Lets say this process gives you two simulation files: one initial simulation that saved it's state before failing (let's call it initial\_simulation.h5), and a second simulation file that continued the initial simulation by loading the saved state of the initial simulation (continued\_simulation.h5). We can combine the events from these two simulation files with PyVQ and plot the results of the complete simulation by running the following example (to plot the magnitude-area distribution):
+
+\begin{verbatim}
+$ python path/to/vq/pyvq/pyvq.py --event_file initial_simulation.h5  --combine_file 
+	continued_simulation.h5 --stress_file file_to_save_sim_state.h5
+	--plot_mag_rupt_area
+\end{verbatim}
+
+More PyVQ examples can be found in Section \ref{sec:pyvq}, and a detailed list of stress simulation parameters can be found in Section \ref{sec:file_params}.
+
+
 \section{Single Element Tutorial\label{sec:Tutorial_single}}
 
 
@@ -2138,7 +2168,7 @@ $ python path/to/vq/pyvq/pyvq.py --event_file path/to/sim_file.h5  --model_file
 
 This section summarizes the current functionality of the pyvq script (section \ref{sec:pyvq}). These parameters do not have default values, and are not used unless specified. 
 
-\subsection{Model parameters}
+\subsection{Model File Parameters}
 
 \noindent %
 \begin{tabular}{|>{\raggedright}p{2in}|>{\raggedright}p{4.1in}|}
@@ -2150,7 +2180,11 @@ This section summarizes the current functionality of the pyvq script (section \r
 \texttt{\small{--model\_file}} & The fault model file.\tabularnewline
 \hline 
 \texttt{\small{--model\_file\_type}} & Either 'hdf5' or 'text'.\tabularnewline
+\hline
+\texttt{\small{--stress\_file}} & hdf5 file containing simulation stress state information.\tabularnewline
 \hline 
+\texttt{\small{--combine\_file}} & An hdf5 simulation file whose events will be combined with those from --event\_file. Must also specify --stress\_file.\tabularnewline
+\hline
 \end{tabular}
 
 \subsection{Subsetting/Filtering Parameters}
@@ -2384,7 +2418,7 @@ remain the same.\tabularnewline
 \end{tabular}
 
 
-\subsection{File name parameters}
+\subsection{File I/O parameters \label{sec:file_params}}
 
 \begin{tabular}{|>{\raggedright}p{2.3in}|>{\raggedright}p{3.8in}|}
 \hline 
@@ -2399,6 +2433,20 @@ not be recorded.\tabularnewline
 not be recorded.\tabularnewline
 \hline 
 \texttt{\small{sim.file.output\_event\_type}} & The file format to output events - must be one of text or hdf5.  If hdf5, sweep and event information will be printed to the same file specified by \texttt{sim.file.output\_event}.\tabularnewline
+\hline 
+\texttt{\small{sim.file.output\_stress}} & The file to output the stress state after a specified number of events, specified by \texttt{sim.file.output\_stress\_num\_events}.\tabularnewline
+\hline 
+\texttt{\small{sim.file.output\_stress\_type}} & The file type for stress output, either text or hdf5. If text, must also specify \texttt{sim.file.output\_stress\_index}.\tabularnewline
+\hline 
+\texttt{\small{sim.file.output\_stress\_index}} & The text file name to write the stress state information. Must be used with \texttt{sim.file.output\_stress}.\tabularnewline
+\hline 
+\texttt{\small{sim.file.output\_stress\_num\_events}} & The number of events before each stress state output.\tabularnewline
+\hline 
+\texttt{\small{sim.file.input\_stress}} & The stress state file used to set initial stresses.\tabularnewline
+\hline 
+\texttt{\small{sim.file.input\_stress\_type}} & The file type for stress input, either text or hdf5. If text, must also specify \texttt{sim.file.input\_stress\_index}.\tabularnewline
+\hline 
+\texttt{\small{sim.file.input\_stress\_index}} & The text file name to load stress state information. Must be used with \texttt{sim.file.input\_stress}.\tabularnewline
 \hline 
 \end{tabular}
 

--- a/examples/check_results.py
+++ b/examples/check_results.py
@@ -18,15 +18,19 @@ def check_self_consistent(events):
     for event in events:
         elements = event.getInvolvedElements()
         element_sweep_slip_sums = {}
+        element_mu = {}
+        element_area = {}
         for elem_id in elements: element_sweep_slip_sums[elem_id] = 0
         summed_moment = 0
         for sweep in event.getSweeps():
             element_sweep_slip_sums[sweep._element_id] += sweep._slip
-            summed_moment += sweep._slip*sweep._area*sweep._mu
+            element_mu[sweep._element_id] = sweep._mu
+            element_area[sweep._element_id] = sweep._area
 
         total_slips = {}
         for elem_num in elements:
             total_slips[elem_num] = event.getEventSlip(elem_num)
+            summed_moment += element_sweep_slip_sums[elem_num]*element_area[elem_num]*element_mu[elem_num]
 
         # Confirm that the sum of sweep slips is equal to the total slip
         for elem_num in total_slips:

--- a/examples/check_results.py
+++ b/examples/check_results.py
@@ -42,6 +42,9 @@ def check_self_consistent(events):
         # yoder: including the 1e7 term in the log argument can cause problems for really big numbers... which is likely indicative of a problem in and
         # of itself, but for now, let's just take it out so we can handle bigger numbers.
         #summed_mag = (2.0/3.0)*math.log10(1e7*summed_moment) - 10.7
+        if (summed_moment <= 0):
+            print("!!! Event {}, Moment {:.5f}, Mag {:.5f}".format(event.getEventNumber(), summed_moment, event.getMagnitude()))
+        
         summed_mag = (2.0/3.0)*(7.0 + math.log10(summed_moment)) - 10.7
         #
         if abs(event.getMagnitude()-summed_mag) > 1e-5:

--- a/quakelib/src/QuakeLib.h
+++ b/quakelib/src/QuakeLib.h
@@ -134,7 +134,7 @@ namespace quakelib {
                 return std::max(_das[0], std::max(_das[1], _das[2]));
             };
 
-        
+
             //! Get the maximum distance along strike of a vertex.
             double min_das(void) {
                 return std::min(_das[0], std::min(_das[1], _das[2]));

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -661,7 +661,7 @@ void quakelib::ModelWorld::create_section(std::vector<unsigned int> &unused_trac
     // Go through the created elements and assign maximum slip based on the total fault area
     // From Table 2A in Wells Coppersmith 1994
     //double moment_magnitude = 4.07+0.98*log10(conv.sqm2sqkm(fault_area));
-    
+
     // Schultz: Updating these to a newer paper. From Leonard 2010
     double moment_magnitude = 4.0+log10(conv.sqm2sqkm(fault_area));
 
@@ -1911,11 +1911,12 @@ int quakelib::ModelWorld::write_file_kml(const std::string &file_name) {
     // Loop thru elements to compute min/max slip rates for color bounds
     double max_rate = 0;
     double min_rate = 0;
+
     for (eit=_elements.begin(); eit!=_elements.end(); ++eit) {
         max_rate = fmax( max_rate, eit->second.slip_rate());
         min_rate = fmin( min_rate, eit->second.slip_rate());
     }
-    
+
     /////// Bounds for color in blue to red range, white in the middle
     double y_min = 0;
     double y_max = 255;
@@ -1948,12 +1949,13 @@ int quakelib::ModelWorld::write_file_kml(const std::string &file_name) {
                     lld[3] = lld[2];
                     lld[2] = c.convert2LatLon(xyz[2]+(xyz[1]-xyz[0]));
                 }
-                
+
                 // Compute blue to red color (RGB)
                 // Keep red scale (min is white, max is red) so red=255
                 // Blue and green are equal and vary from (255 for min vals to 0 for max vals)
                 int blue, green;
                 int red = y_max;
+
                 if (eit->second.slip_rate() == 0) {
                     blue = 0;
                     green = 0;
@@ -1963,7 +1965,7 @@ int quakelib::ModelWorld::write_file_kml(const std::string &file_name) {
                     blue = y_max - interp_color;
                     green = blue;
                 }
-                
+
                 // Output the KML format polygon for this element
                 out_file << "\t\t<Placemark>\n";
                 out_file << "\t\t<description>\n";
@@ -1975,11 +1977,11 @@ int quakelib::ModelWorld::write_file_kml(const std::string &file_name) {
                 out_file << "\t\t</description>\n";
                 out_file << "\t\t\t<Style>\n";
                 out_file << "\t\t\t\t<LineStyle>\n";
-                out_file << "\t\t\t\t\t<color>"<< rgb2hex(red, green, blue) <<"</color>\n"; 
-                out_file << "\t\t\t\t\t<width>1</width>\n"; 
+                out_file << "\t\t\t\t\t<color>"<< rgb2hex(red, green, blue) <<"</color>\n";
+                out_file << "\t\t\t\t\t<width>1</width>\n";
                 out_file << "\t\t\t\t</LineStyle>\n";
                 out_file << "\t\t\t\t<PolyStyle>\n";
-                out_file << "\t\t\t\t\t<color>"<< rgb2hex(red, green, blue) <<"</color>\n"; 
+                out_file << "\t\t\t\t\t<color>"<< rgb2hex(red, green, blue) <<"</color>\n";
                 out_file << "\t\t\t\t</PolyStyle>\n";
                 out_file << "\t\t\t</Style>\n";
                 //out_file << "\t\t\t<styleUrl>#baseStyle</styleUrl>\n";
@@ -2018,7 +2020,7 @@ double quakelib::ModelWorld::linear_interp(const double &x, const double &x_min,
     return ((y_max - y_min)/(x_max - x_min) * (x - x_min)) + y_min;
 }
 
-char* quakelib::ModelWorld::rgb2hex(const int r, const int g, const int b) const {
+char *quakelib::ModelWorld::rgb2hex(const int r, const int g, const int b) const {
     // Returning ABGR to work with KML format
     char *buf;
     size_t sz;
@@ -2052,9 +2054,9 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
     dx = max_xyz[0]-min_xyz[0];
     dy = max_xyz[1]-min_xyz[1];
     range = fmax(dx, dy) * (1.0/tan(c.deg2rad(30)));
-    
+
     double max_depth = fabs(min_bound.altitude());
-    
+
     //// Get relevant event info
     involved_elements = event.getInvolvedElements();
     trigger = event.getEventTrigger();
@@ -2101,8 +2103,10 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
     ModelVertex     vert;
 
     eit = _elements.find(trigger);
+
     for (i=0; i<3; ++i) {
         cur_alt = _vertices.find(eit->second.vertex(i))->second.lld().altitude();
+
         if (cur_alt < min_altitude) {
             min_altitude = cur_alt;
             best_vertex = eit->second.vertex(i);
@@ -2118,21 +2122,22 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
     // Loop thru elements to compute min/max slip rates for color bounds
     double max_slip = -DBL_MAX;
     double min_slip = DBL_MAX;
+
     for (it=involved_elements.begin(); it!=involved_elements.end(); ++it) {
         max_slip = fmax( max_slip, event.getEventSlip(*it));
         min_slip = fmin( min_slip, event.getEventSlip(*it));
         involved_sections.insert(_elements.find(*it)->second.section_id());
     }
 
-    // Add all the elements from the involved sections, regardless if they 
-    // actually slipped in the event. The ones with no slip will fill out the 
+    // Add all the elements from the involved sections, regardless if they
+    // actually slipped in the event. The ones with no slip will fill out the
     // faults and be nearly transparent.
-    for (eit=_elements.begin();eit!=_elements.end(); ++eit) {
+    for (eit=_elements.begin(); eit!=_elements.end(); ++eit) {
         if (involved_sections.count(eit->second.section_id())) {
             all_elements.insert(eit->first);
         }
     }
-    
+
     /////// Bounds for color in blue to red range, white in the middle
     double y_min = -255;
     double y_max = 255;
@@ -2140,6 +2145,7 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
     double x_min = -x_max;
 
     out_file << "<Folder id=\"elements\">\n";
+
     // Go through the involved elements
     for (it=all_elements.begin(); it!=all_elements.end(); ++it) {
         LatLonDepth         lld[4];
@@ -2160,12 +2166,13 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
             lld[3] = lld[2];
             lld[2] = c.convert2LatLon(xyz[2]+(xyz[1]-xyz[0]));
         }
-        
+
         // If the element is involved in the event..
         // Compute blue to red color (RGB)
         if (involved_elements.count(*it)) {
             int blue, green, red;
             int interp_color = (int) linear_interp(event.getEventSlip(*it), x_min, x_max, y_min, y_max);
+
             if (interp_color > 0) {
                 // More red
                 red = y_max;
@@ -2176,7 +2183,7 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
                 red = y_max - abs(interp_color);
                 green = red;
             }
-            
+
             // Output the KML format polygon for this element
             out_file << "\t\t<Placemark>\n";
             out_file << "\t\t<description>\n";
@@ -2185,11 +2192,11 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
             out_file << "\t\t</description>\n";
             out_file << "\t\t\t<Style>\n";
             out_file << "\t\t\t\t<LineStyle>\n";
-            out_file << "\t\t\t\t\t<color>"<< rgb2hex(red, green, blue) <<"</color>\n"; 
-            out_file << "\t\t\t\t\t<width>1</width>\n"; 
+            out_file << "\t\t\t\t\t<color>"<< rgb2hex(red, green, blue) <<"</color>\n";
+            out_file << "\t\t\t\t\t<width>1</width>\n";
             out_file << "\t\t\t\t</LineStyle>\n";
             out_file << "\t\t\t\t<PolyStyle>\n";
-            out_file << "\t\t\t\t\t<color>"<< rgb2hex(red, green, blue) <<"</color>\n"; 
+            out_file << "\t\t\t\t\t<color>"<< rgb2hex(red, green, blue) <<"</color>\n";
             out_file << "\t\t\t\t</PolyStyle>\n";
             out_file << "\t\t\t</Style>\n";
             out_file << "\t\t\t<Polygon>\n";
@@ -2208,7 +2215,7 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
             out_file << "\t\t\t</Polygon>\n";
             out_file << "\t\t</Placemark>\n";
         } else {
-        // If this element wasn't involved in the event and is included to fill out the fault
+            // If this element wasn't involved in the event and is included to fill out the fault
             // Output the KML format polygon for this element
             out_file << "\t\t<Placemark>\n";
             out_file << "\t\t<description>\n";
@@ -2216,11 +2223,11 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
             out_file << "\t\t</description>\n";
             out_file << "\t\t\t<Style>\n";
             out_file << "\t\t\t\t<LineStyle>\n";
-            out_file << "\t\t\t\t\t<color>66FFFFFF</color>\n"; 
-            out_file << "\t\t\t\t\t<width>1</width>\n"; 
+            out_file << "\t\t\t\t\t<color>66FFFFFF</color>\n";
+            out_file << "\t\t\t\t\t<width>1</width>\n";
             out_file << "\t\t\t\t</LineStyle>\n";
             out_file << "\t\t\t\t<PolyStyle>\n";
-            out_file << "\t\t\t\t\t<color>66FFFFFF</color>\n"; 
+            out_file << "\t\t\t\t\t<color>66FFFFFF</color>\n";
             out_file << "\t\t\t\t</PolyStyle>\n";
             out_file << "\t\t\t</Style>\n";
             out_file << "\t\t\t<Polygon>\n";
@@ -2576,23 +2583,27 @@ double quakelib::ModelWorld::section_length(const quakelib::UIndex &sec_id) cons
     std::map<UIndex, ModelElement>::const_iterator  eit;
     double min_das = DBL_MAX;
     double max_das = -DBL_MAX;
+
     for (eit=_elements.begin(); eit!=_elements.end(); ++eit) {
         if (eit->second.section_id() == sec_id) {
             min_das = fmin(min_das, create_sim_element(eit->first).min_das());
             max_das = fmax(max_das, create_sim_element(eit->first).max_das());
         }
     }
+
     return max_das-min_das;
 }
 
 double quakelib::ModelWorld::section_max_depth(const quakelib::UIndex &sec_id) const {
     std::map<UIndex, ModelElement>::const_iterator  eit;
     double max_depth = DBL_MAX;
+
     for (eit=_elements.begin(); eit!=_elements.end(); ++eit) {
         if (eit->second.section_id() == sec_id) {
             max_depth = fmin(max_depth, create_sim_element(eit->first).max_depth());
         }
     }
+
     return max_depth;
 }
 
@@ -3436,7 +3447,7 @@ int quakelib::ModelEventSet::append_from_hdf5(const std::string &file_name, cons
 #ifdef HDF5_FOUND
     hid_t       plist_id, data_file;
     herr_t      res;
-    
+
     std::cout << "## Combining with events from " << file_name << std::endl;
 
     if (!H5Fis_hdf5(file_name.c_str())) return -1;
@@ -3503,7 +3514,7 @@ void quakelib::ModelEventSet::append_events_hdf5(const hid_t &data_file, const d
 
     unsigned int the_last_evnum = _events[_events.size()-1].getEventNumber();
     std::cout << "# Appending events after event number " << the_last_evnum <<  std::endl;
-    
+
     for (i=0; i<num_events; ++i) {
         ModelEvent  new_event;
         new_event.read_data(event_data[i]);
@@ -3511,6 +3522,7 @@ void quakelib::ModelEventSet::append_events_hdf5(const hid_t &data_file, const d
         //std::cout << "Read event " << new_event.getEventNumber() << ", trigger = " << new_event.getEventTrigger() << std::endl;
         new_event.setEventNumber(new_event.getEventNumber()+add_evnum);
         new_event.setEventYear(new_event.getEventYear()+add_year);
+
         // Only add it if it's not in _events already
         if (new_event.getEventNumber() > the_last_evnum) {
             _events.push_back(new_event);
@@ -3780,7 +3792,7 @@ void quakelib::ModelStress::get_field_descs(std::vector<quakelib::FieldDesc> &de
     field_desc.size = sizeof(float);
 #endif
     descs.push_back(field_desc);
-    
+
     field_desc.name = "slip_deficit";
     field_desc.details = "Slip deficit for the element (meters).";
 #ifdef HDF5_FOUND
@@ -3907,7 +3919,7 @@ void quakelib::ModelStressState::append_stress_state_hdf5(const hid_t &data_file
         field_offsets[i] = descs[i].offset;
         field_sizes[i] = descs[i].size;
     }
-    
+
     // Add to the stress state table
     res = H5TBappend_records(data_file,
                              ModelStressState::hdf5_table_name().c_str(),
@@ -3918,7 +3930,7 @@ void quakelib::ModelStressState::append_stress_state_hdf5(const hid_t &data_file
                              &_times);
 
     if (res < 0) exit(-1);
-    
+
     // Free memory for HDF5 related data
     delete [] field_offsets;
     delete [] field_sizes;
@@ -3941,9 +3953,11 @@ int quakelib::ModelStressSet::read_file_hdf5(const std::string &file_name) {
     if (!H5Fis_hdf5(file_name.c_str())) return -1;
 
     plist_id = H5Pcreate(H5P_FILE_ACCESS);
+
     if (plist_id < 0) exit(-1);
 
     data_file = H5Fopen(file_name.c_str(), H5F_ACC_RDONLY, plist_id);
+
     if (data_file < 0) exit(-1);
 
     // Read the state data from the file, grab the time data and number of stress records per state
@@ -3959,12 +3973,13 @@ int quakelib::ModelStressSet::read_file_hdf5(const std::string &file_name) {
     }
 
     res = H5TBget_table_info(data_file, ModelStressState::hdf5_table_name().c_str(), &num_fields, &num_states);
-    if (res < 0) exit(-1); 
-    
+
+    if (res < 0) exit(-1);
+
     // Read all the stress time/num_recs data for all states
     state_data = new StressDataTime[num_states];
     res = H5TBread_records(data_file, ModelStressState::hdf5_table_name().c_str(), 0, num_states, sizeof(StressDataTime), field_offsets_state, field_sizes_state, state_data);
-    
+
     // Prepare for stress table reading
     descs.clear();
     ModelStress::get_field_descs(descs);
@@ -3976,22 +3991,24 @@ int quakelib::ModelStressSet::read_file_hdf5(const std::string &file_name) {
         field_offsets_stress[i] = descs[i].offset;
         field_sizes_stress[i] = descs[i].size;
     }
-   
+
     // Read all the stress data entries, we will parse them to the appropriate stress state later
     res = H5TBget_table_info(data_file, ModelStress::hdf5_table_name().c_str(), &num_fields, &num_stresses);
-    if (res < 0) exit(-1); 
-   
+
+    if (res < 0) exit(-1);
+
     stress_data = new StressData[num_stresses];
     res = H5TBread_records(data_file, ModelStress::hdf5_table_name().c_str(), 0, num_stresses, sizeof(StressData), field_offsets_stress, field_sizes_stress, stress_data);
-   
+
     // For each state, set the stress data
     for (i=0; i<num_states; ++i) {
         // Create the stress state, read the data
         ModelStressState new_state;
         new_state.read_data(state_data[i]);
-        
+
         // Create this state's stress data, and read the corresponding stress records
-        ModelStress new_stress; 
+        ModelStress new_stress;
+
         for (j=new_state.getStartRec(); j<new_state.getEndRec(); ++j) {
             new_stress.add_stress_entry(stress_data[j]);
         }
@@ -4010,8 +4027,8 @@ int quakelib::ModelStressSet::read_file_hdf5(const std::string &file_name) {
     res = H5Fclose(data_file);
 
     if (res < 0) exit(-1);
-    
-    
+
+
     // Free memory for HDF5 related data
     // yoder: ... and use delete [] for arrays...
     delete [] stress_data;
@@ -4071,14 +4088,14 @@ void quakelib::ModelStressState::get_field_descs(std::vector<quakelib::FieldDesc
 #endif
     descs.push_back(field_desc);
 
-//    field_desc.name = "sweep_num";
-//    field_desc.details = "Sweep number this stress state corresponds to.";
-//#ifdef HDF5_FOUND
-//    field_desc.offset = HOFFSET(StressDataTime, _sweep_num);
-//    field_desc.type = H5T_NATIVE_UINT;
-//    field_desc.size = sizeof(unsigned int);
-//#endif
-//    descs.push_back(field_desc);
+    //    field_desc.name = "sweep_num";
+    //    field_desc.details = "Sweep number this stress state corresponds to.";
+    //#ifdef HDF5_FOUND
+    //    field_desc.offset = HOFFSET(StressDataTime, _sweep_num);
+    //    field_desc.type = H5T_NATIVE_UINT;
+    //    field_desc.size = sizeof(unsigned int);
+    //#endif
+    //    descs.push_back(field_desc);
 
     field_desc.name = "start_rec";
     field_desc.details = "Starting record of stress values for this time.";
@@ -4127,7 +4144,7 @@ int quakelib::ModelStressSet::read_file_ascii(const std::string &stress_index_fi
     // Close the files
     stress_ind_file.close();
     stress_file.close();
-    
+
     std::cout << "==== Read stress state from file ====" << std::endl;
     return 0;
 }

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -3755,7 +3755,7 @@ void quakelib::ModelStressState::append_stress_state_hdf5(const hid_t &data_file
         field_offsets[i] = descs[i].offset;
         field_sizes[i] = descs[i].size;
     }
-
+    
     // Add to the stress state table
     res = H5TBappend_records(data_file,
                              ModelStressState::hdf5_table_name().c_str(),
@@ -3766,7 +3766,7 @@ void quakelib::ModelStressState::append_stress_state_hdf5(const hid_t &data_file
                              &_times);
 
     if (res < 0) exit(-1);
-
+    
     // Free memory for HDF5 related data
     delete [] field_offsets;
     delete [] field_sizes;

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -1100,6 +1100,11 @@ namespace quakelib {
     class ModelStressSet {
         private:
             std::vector<ModelStressState>   _states;
+            
+#ifdef HDF5_FOUND
+            void read_state_hdf5(const hid_t &data_file);
+            void read_stress_hdf5(const hid_t &data_file);
+#endif
 
         public:
             typedef std::vector<ModelStressState>::iterator         iterator;
@@ -1129,6 +1134,7 @@ namespace quakelib {
             };
 
             int read_file_ascii(const std::string &stress_index_file_name, const std::string &stress_file_name);
+            int read_file_hdf5(const std::string &file_name);
     };
 
     class ModelWorld : public ModelIO {

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -975,6 +975,10 @@ namespace quakelib {
                 new_entry._slip_deficit = slip_deficit;
                 _data.push_back(new_entry);
             }
+            
+            void add_stress_entry(StressData &new_entry) {
+                _data.push_back(new_entry);
+            }
 #ifdef HDF5_FOUND
             static std::string hdf5_table_name(void) {
                 return "stresses";
@@ -1047,6 +1051,7 @@ namespace quakelib {
             };
             static void setup_stress_state_hdf5(const hid_t &data_file);
             void append_stress_state_hdf5(const hid_t &data_file) const;
+            void read_data(const StressDataTime &in_data);
 #endif
             static void get_field_descs(std::vector<FieldDesc> &descs);
             static void write_ascii_header(std::ostream &out_stream);
@@ -1089,6 +1094,14 @@ namespace quakelib {
             }
             unsigned int getNumStressRecords(void) const {
                 return _times._end_rec - _times._start_rec;
+            };
+            
+            unsigned int getStartRec(void) const {
+                return _times._start_rec;
+            };
+            
+            unsigned int getEndRec(void) const {
+                return _times._end_rec;
             };
 
             void read_ascii(std::istream &in_stream);

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -909,10 +909,12 @@ namespace quakelib {
     class ModelEventSet {
         private:
             std::vector<ModelEvent>     _events;
+#ifdef HDF5_FOUND
             void read_events_hdf5(const hid_t &data_file);
             void read_sweeps_hdf5(const hid_t &data_file);
             void append_events_hdf5(const hid_t &data_file, const double &add_year, const unsigned int &add_evnum);
             void append_sweeps_hdf5(const hid_t &data_file, const unsigned int &last_evnum);
+#endif
 
         public:
             typedef std::vector<ModelEvent>::iterator       iterator;

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -579,6 +579,12 @@ namespace quakelib {
                 return _sweeps.end();
             };
 
+            void resetEventNumbers(const double &new_num) {
+                for (std::vector<SweepData>::iterator it=_sweeps.begin(); it!=_sweeps.end(); ++it) {
+                    it->_event_number = new_num;
+                }
+            }
+
             void setSlipAndArea(const UIndex &sweep_number, const UIndex &element_id, const double &slip, const double &area, const double &mu) {
                 unsigned int    pos = sweepElementPos(sweep_number, element_id);
                 _sweeps[pos]._slip = slip;
@@ -905,6 +911,8 @@ namespace quakelib {
             std::vector<ModelEvent>     _events;
             void read_events_hdf5(const hid_t &data_file);
             void read_sweeps_hdf5(const hid_t &data_file);
+            void append_events_hdf5(const hid_t &data_file, const double &add_year, const unsigned int &add_evnum);
+            void append_sweeps_hdf5(const hid_t &data_file, const unsigned int &last_evnum);
 
         public:
             typedef std::vector<ModelEvent>::iterator       iterator;
@@ -936,6 +944,7 @@ namespace quakelib {
             int read_file_ascii(const std::string &event_file_name, const std::string &sweep_file_name);
 
             int read_file_hdf5(const std::string &file_name);
+            int append_from_hdf5(const std::string &file_name, const double &add_year, const unsigned int &add_evnum);
     };
 
     /*!

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -1078,16 +1078,7 @@ namespace quakelib {
             UIndex getEventNum(void) const {
                 return _times._event_num;
             }
-        
-            // Schultz: For the first version of the stress in/out, lets not write mid-event.
-            // If we write between events, then we don't need sweep info.
-        
-            //void setSweepNum(const UIndex sweep_num) {
-            //    _times._sweep_num = sweep_num;
-            //}
-            //UIndex getSweepNum(void) const {
-            //    return _times._sweep_num;
-            //}
+
             void setStartEndRecNums(const unsigned int start_rec, const unsigned int end_rec) {
                 _times._start_rec = start_rec;
                 _times._end_rec = end_rec;

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -948,7 +948,7 @@ namespace quakelib {
         UIndex          _element_id;
 
         //! Shear and normal stress on the element at this time
-        float          _shear_stress, _normal_stress;
+        float          _shear_stress, _normal_stress, _slip_deficit;
     };
 
     /*!
@@ -967,11 +967,12 @@ namespace quakelib {
                 _data.clear();
             }
 
-            void add_stress_entry(UIndex element_id, float shear_stress, float normal_stress) {
+            void add_stress_entry(UIndex element_id, float shear_stress, float normal_stress, float slip_deficit) {
                 StressData new_entry;
                 new_entry._element_id = element_id;
                 new_entry._shear_stress = shear_stress;
                 new_entry._normal_stress = normal_stress;
+                new_entry._slip_deficit = slip_deficit;
                 _data.push_back(new_entry);
             }
 #ifdef HDF5_FOUND

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -984,7 +984,7 @@ namespace quakelib {
                 new_entry._slip_deficit = slip_deficit;
                 _data.push_back(new_entry);
             }
-            
+
             void add_stress_entry(StressData &new_entry) {
                 _data.push_back(new_entry);
             }
@@ -1095,11 +1095,11 @@ namespace quakelib {
             unsigned int getNumStressRecords(void) const {
                 return _times._end_rec - _times._start_rec;
             };
-            
+
             unsigned int getStartRec(void) const {
                 return _times._start_rec;
             };
-            
+
             unsigned int getEndRec(void) const {
                 return _times._end_rec;
             };
@@ -1113,7 +1113,7 @@ namespace quakelib {
     class ModelStressSet {
         private:
             std::vector<ModelStressState>   _states;
-            
+
 #ifdef HDF5_FOUND
             void read_state_hdf5(const hid_t &data_file);
             void read_stress_hdf5(const hid_t &data_file);
@@ -1272,9 +1272,9 @@ namespace quakelib {
 
             int read_files_eqsim(const std::string &geom_file_name, const std::string &cond_file_name, const std::string &fric_file_name);
             int write_files_eqsim(const std::string &geom_file_name, const std::string &cond_file_name, const std::string &fric_file_name);
-            
+
             double linear_interp(const double &x, const double &x_min, const double &x_max, const double &y_min, const double &y_max) const;
-            char* rgb2hex(const int r, const int g, const int b) const;
+            char *rgb2hex(const int r, const int g, const int b) const;
             double section_length(const UIndex &sec_id) const;
             double section_max_depth(const UIndex &sec_id) const;
     };

--- a/src/core/InitBlocks.cpp
+++ b/src/core/InitBlocks.cpp
@@ -65,7 +65,7 @@ void VCInitBlocks::init(SimFramework *_sim) {
     // If it has already been set by reading in a stress file, do not overwrite it
     if (sim->getYear() > 0.0) {
         sim->console() << "Beginning sim at year " << sim->getYear() << "." << std::endl;
-    } else { 
+    } else {
         sim->setYear(sim->getSimStart());
     }
 

--- a/src/core/InitBlocks.cpp
+++ b/src/core/InitBlocks.cpp
@@ -62,7 +62,12 @@ void VCInitBlocks::init(SimFramework *_sim) {
                      sim->useTransposedMatrix());
 
     // Set the starting year of the simulation
-    sim->setYear(sim->getSimStart());
+    // If it has already been set by reading in a stress file, do not overwrite it
+    if (sim->getYear() > 0.0) {
+        sim->console() << "Beginning sim at year " << sim->getYear() << "." << std::endl;
+    } else { 
+        sim->setYear(sim->getSimStart());
+    }
 
     // Determine neighbors of blocks
     // Schultz: Removing this for now, we don't use these anymore in dynamic failure check

--- a/src/core/Params.cpp
+++ b/src/core/Params.cpp
@@ -86,12 +86,12 @@ void VCParams::read_params(const std::string &param_file_name) {
     params.readSet<string>("sim.file.output_stress_index", "");
     params.readSet<string>("sim.file.output_stress_type", "");
     params.readSet<unsigned int>("sim.file.output_stress_num_events", std::numeric_limits<unsigned int>::max());
-    
+
     params.readSet<string>("sim.file.input_stress", "");
     params.readSet<string>("sim.file.input_stress_index", "");
     params.readSet<string>("sim.file.input_stress_type", "");
-    
-    
+
+
     //
     // yoder: add parameters to truncate crazy greens function values:
     //params.readSet<double>("sim.greens.shear_max",  std::numeric_limits<double>::max());
@@ -119,7 +119,7 @@ void VCParams::read_params(const std::string &param_file_name) {
     params.readSet<bool>("sim.friction.compute_stress_drops", true);
 
     params.readSet<double>("sim.friction.stress_drop_factor", 0.4);
-    
+
     params.readSet<bool>("sim.friction.dynamic_stress_drops", false);
 
 }

--- a/src/core/Params.cpp
+++ b/src/core/Params.cpp
@@ -85,10 +85,12 @@ void VCParams::read_params(const std::string &param_file_name) {
     params.readSet<string>("sim.file.output_stress", "");
     params.readSet<string>("sim.file.output_stress_index", "");
     params.readSet<string>("sim.file.output_stress_type", "");
+    params.readSet<unsigned int>("sim.file.output_stress_num_events", std::numeric_limits<unsigned int>::max());
     
     params.readSet<string>("sim.file.input_stress", "");
     params.readSet<string>("sim.file.input_stress_index", "");
     params.readSet<string>("sim.file.input_stress_type", "");
+    
     
     //
     // yoder: add parameters to truncate crazy greens function values:
@@ -116,7 +118,7 @@ void VCParams::read_params(const std::string &param_file_name) {
     // Kasey: parameter to either read in stress drops from file or compute them
     params.readSet<bool>("sim.friction.compute_stress_drops", true);
 
-    params.readSet<double>("sim.friction.stress_drop_factor", 0.5);
+    params.readSet<double>("sim.friction.stress_drop_factor", 0.4);
     
     params.readSet<bool>("sim.friction.dynamic_stress_drops", false);
 

--- a/src/core/Params.h
+++ b/src/core/Params.h
@@ -166,11 +166,11 @@ class VCParams {
         std::string getStressOutfileType(void) const {
             return params.read<string>("sim.file.output_stress_type");
         };
-    
+
         int getStressOutInterval(void) const {
             return params.read<unsigned int>("sim.file.output_stress_num_events");
         };
-    
+
         std::string getStressInfile(void) const {
             return params.read<string>("sim.file.input_stress");
         };
@@ -180,7 +180,7 @@ class VCParams {
         std::string getStressInfileType(void) const {
             return params.read<string>("sim.file.input_stress_type");
         };
-    
+
         //
         // yoder: helper functions for greens function max/min values:
         // can we make a (set of) generic pramGetter(str.pram_name) function(s)? then, we can add params at will...

--- a/src/core/Params.h
+++ b/src/core/Params.h
@@ -167,6 +167,10 @@ class VCParams {
             return params.read<string>("sim.file.output_stress_type");
         };
     
+        int getStressOutInterval(void) const {
+            return params.read<unsigned int>("sim.file.output_stress_num_events");
+        };
+    
         std::string getStressInfile(void) const {
             return params.read<string>("sim.file.input_stress");
         };

--- a/src/core/SimData.cpp
+++ b/src/core/SimData.cpp
@@ -131,7 +131,7 @@ void VCSimData::deallocateArrays(void) {
     if (rhogd) free(rhogd);
 
     if (stress_drop) free(stress_drop);
-    
+
     if (max_stress_drop) free(max_stress_drop);
 
     if (cff) free(cff);

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -73,7 +73,10 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
     quakelib::ModelStressState  stress_state;
     unsigned int                gid;
 
-    if (getStressOutfileType() == "") return;
+    if (getStressOutfileType() == "") {
+        console() << "No stress output type specified, so not writing." << std::endl;
+        return;
+    }
 
 #ifdef MPI_C_FOUND
     // note: this does nothing if not MPI_C_FOUND

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -74,37 +74,153 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
     unsigned int                gid;
 
     if (getStressOutfileType() == "") return;
-
+    
+#ifdef MPI_C_FOUND
+    // note: this does nothing if not MPI_C_FOUND
+    int                             i, num_local_blocks, total_block_count;
+    int                             *counts, *offsets;
+    BlockVal                        *slip_vals, *all_slips;
+    BlockVal                        *shear_vals, *all_shear;
+    BlockVal                        *normal_vals, *all_normal;
+    
+    // Gather the number of blocks per node at the root
+    num_local_blocks = numLocalBlocks();
+    
+    if (isRootNode()) {
+        counts = new int[world_size];
+        offsets = new int[world_size];
+    } else {
+        counts = offsets = NULL;
+    }
+    
+    MPI_Gather(&num_local_blocks, 1, MPI_INT, counts, 1, MPI_INT, ROOT_NODE_RANK, MPI_COMM_WORLD);
+    
+    // Record the number of blocks the root will receive from each node
+    if (isRootNode()) {
+        total_block_count = 0;
+        
+        for (i=0; i<world_size; ++i) {
+            // note: this gives the starting position of blocks from each node (first node starts at position i=0,
+            // second at i=n_0, third at i=n_1, etc.)
+            offsets[i] = total_block_count;
+            total_block_count += counts[i];
+        }
+        assertThrow(total_block_count == numGlobalBlocks(), "Number of total blocks mismatch among processors.")
+    }
+    
+    // Record the values of each block on this proc
+    slip_vals = new BlockVal[numLocalBlocks()];
+    shear_vals = new BlockVal[numLocalBlocks()];
+    normal_vals = new BlockVal[numLocalBlocks()];
+    
+    if (isRootNode()) all_slips = new BlockVal[numGlobalBlocks()];
+    if (isRootNode()) all_shear = new BlockVal[numGlobalBlocks()];
+    if (isRootNode()) all_normal = new BlockVal[numGlobalBlocks()];
+    
+    // Copy local block info to the local array
+    for (i=0; i<numLocalBlocks(); ++i) {
+        gid = getGlobalBID(i);
+        slip_vals[i].val = getSlipDeficit(gid);
+        slip_vals[i].block_id = gid;
+        shear_vals[i].val = getShearStress(gid);
+        shear_vals[i].block_id = gid;
+        normal_vals[i].val = getNormalStress(gid);
+        normal_vals[i].block_id = gid;
+    }
+    
+    // Gather the slip info at the root node
+    MPI_Gatherv(slip_vals, numLocalBlocks(), block_val_type,
+                all_slips, counts, offsets, block_val_type,
+                ROOT_NODE_RANK, MPI_COMM_WORLD);
+    
+    // Gather the shear stress info at the root node
+    MPI_Gatherv(shear_vals, numLocalBlocks(), block_val_type,
+                all_shear, counts, offsets, block_val_type,
+                ROOT_NODE_RANK, MPI_COMM_WORLD);
+    
+    // Gather the normal stress info at the root node
+    MPI_Gatherv(normal_vals, numLocalBlocks(), block_val_type,
+                all_normal, counts, offsets, block_val_type,
+                ROOT_NODE_RANK, MPI_COMM_WORLD);
+    
+    // Write out the state for all blocks on the root node
+    if (isRootNode()) {
+        stress_state.setYear(getYear());
+        stress_state.setEventNum(event_num);
+        stress_state.setStartEndRecNums(num_stress_recs, num_stress_recs+numGlobalBlocks());
+        
+        for (i=0; i<numGlobalBlocks(); ++i) {
+            BlockID         bid = all_slips[i].block_id;
+            stress.add_stress_entry(bid, all_shear[i].val, all_normal[i].val, all_slips[i].val);
+            std::cout << bid << "  " << all_shear[i].val << "  " << all_normal[i].val << "  " << all_slips[i].val << std::endl;
+        }
+        
+        num_stress_recs += numGlobalBlocks();
+        
+        if (getStressOutfileType() == "text") {
+            // Write the stress state details
+            stress_state.write_ascii(stress_index_outfile);
+            stress_index_outfile.flush();
+            
+            // Write the stress details
+            stress.write_ascii(stress_outfile);
+            stress_outfile.flush();
+        } else if (getStressOutfileType() == "hdf5") {
+            // Write the stress state details
+            stress_state.append_stress_state_hdf5(stress_data_file);
+            
+            // Write the stress details
+            stress.append_stress_hdf5(stress_data_file);
+        }
+        
+        H5Fclose(stress_data_file);
+        
+        // use delete [] for arrays:
+        if (isRootNode()) {
+            delete [] counts;
+            delete [] offsets;
+            delete [] all_slips;
+            delete [] all_shear;
+            delete [] all_normal;
+        } else {
+            delete counts;
+            delete offsets;
+            delete all_slips;
+            delete all_normal;
+            delete all_shear;
+        }
+    }
+    
+#else
+    
     stress_state.setYear(getYear());
     stress_state.setEventNum(event_num);
-    //stress_state.setSweepNum(sweep_num);
     stress_state.setStartEndRecNums(num_stress_recs, num_stress_recs+numGlobalBlocks());
-
-    // Communicate all values between nodes
-
-
+    
     for (unsigned int i=0; i<numGlobalBlocks(); ++i) {
-        // TODO: Figure this out for multi-proc
         stress.add_stress_entry(i, shear_stress[i], normal_stress[i], slip_deficit[i]);
     }
-
+    
     num_stress_recs += numGlobalBlocks();
-
+    
     if (getStressOutfileType() == "text") {
         // Write the stress state details
         stress_state.write_ascii(stress_index_outfile);
         stress_index_outfile.flush();
-
+        
         // Write the stress details
         stress.write_ascii(stress_outfile);
         stress_outfile.flush();
     } else if (getStressOutfileType() == "hdf5") {
         // Write the stress state details
         stress_state.append_stress_state_hdf5(stress_data_file);
-
+        
         // Write the stress details
         stress.append_stress_hdf5(stress_data_file);
     }
+    
+#endif
+    
 }
 
 /*!

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -175,8 +175,6 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
             
         }
         
-        H5Fclose(stress_data_file);
-        
         // use delete [] for arrays:
         if (isRootNode()) {
             delete [] counts;

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -81,7 +81,10 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
 
     // Store stress values
     for (unsigned int i=0; i<numGlobalBlocks(); ++i) {
-        stress.add_stress_entry(i, shear_stress[i], normal_stress[i], slip_deficit[i]);
+        // TODO: Figure this out for multi-proc
+        if (isLocalBlockID(i)) {
+            stress.add_stress_entry(i, shear_stress[i], normal_stress[i], slip_deficit[i]);
+        }
     }
 
     num_stress_recs += numGlobalBlocks();

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -74,7 +74,7 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
     unsigned int                gid;
 
     if (getStressOutfileType() == "") return;
-    
+
 #ifdef MPI_C_FOUND
     // note: this does nothing if not MPI_C_FOUND
     int                             i, num_local_blocks, total_block_count;
@@ -82,41 +82,44 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
     BlockVal                        *slip_vals, *all_slips;
     BlockVal                        *shear_vals, *all_shear;
     BlockVal                        *normal_vals, *all_normal;
-    
+
     // Gather the number of blocks per node at the root
     num_local_blocks = numLocalBlocks();
-    
+
     if (isRootNode()) {
         counts = new int[world_size];
         offsets = new int[world_size];
     } else {
         counts = offsets = NULL;
     }
-    
+
     MPI_Gather(&num_local_blocks, 1, MPI_INT, counts, 1, MPI_INT, ROOT_NODE_RANK, MPI_COMM_WORLD);
-    
+
     // Record the number of blocks the root will receive from each node
     if (isRootNode()) {
         total_block_count = 0;
-        
+
         for (i=0; i<world_size; ++i) {
             // note: this gives the starting position of blocks from each node (first node starts at position i=0,
             // second at i=n_0, third at i=n_1, etc.)
             offsets[i] = total_block_count;
             total_block_count += counts[i];
         }
+
         assertThrow(total_block_count == numGlobalBlocks(), "Number of total blocks mismatch among processors.")
     }
-    
+
     // Record the values of each block on this proc
     slip_vals = new BlockVal[numLocalBlocks()];
     shear_vals = new BlockVal[numLocalBlocks()];
     normal_vals = new BlockVal[numLocalBlocks()];
-    
+
     if (isRootNode()) all_slips = new BlockVal[numGlobalBlocks()];
+
     if (isRootNode()) all_shear = new BlockVal[numGlobalBlocks()];
+
     if (isRootNode()) all_normal = new BlockVal[numGlobalBlocks()];
-    
+
     // Copy local block info to the local array
     for (i=0; i<numLocalBlocks(); ++i) {
         gid = getGlobalBID(i);
@@ -127,54 +130,54 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
         normal_vals[i].val = getNormalStress(gid);
         normal_vals[i].block_id = gid;
     }
-    
+
     // Gather the slip info at the root node
     MPI_Gatherv(slip_vals, numLocalBlocks(), block_val_type,
                 all_slips, counts, offsets, block_val_type,
                 ROOT_NODE_RANK, MPI_COMM_WORLD);
-    
+
     // Gather the shear stress info at the root node
     MPI_Gatherv(shear_vals, numLocalBlocks(), block_val_type,
                 all_shear, counts, offsets, block_val_type,
                 ROOT_NODE_RANK, MPI_COMM_WORLD);
-    
+
     // Gather the normal stress info at the root node
     MPI_Gatherv(normal_vals, numLocalBlocks(), block_val_type,
                 all_normal, counts, offsets, block_val_type,
                 ROOT_NODE_RANK, MPI_COMM_WORLD);
-    
+
     // Write out the state for all blocks on the root node
     if (isRootNode()) {
         stress_state.setYear(getYear());
         stress_state.setEventNum(event_num);
         stress_state.setStartEndRecNums(num_stress_recs, num_stress_recs+numGlobalBlocks());
-        
+
         for (i=0; i<numGlobalBlocks(); ++i) {
             BlockID         bid = all_slips[i].block_id;
             stress.add_stress_entry(bid, all_shear[i].val, all_normal[i].val, all_slips[i].val);
             // Debug output
             // std::cout << bid << "  " << all_shear[i].val << "  " << all_normal[i].val << "  " << all_slips[i].val << std::endl;
         }
-        
+
         num_stress_recs += numGlobalBlocks();
-        
+
         if (getStressOutfileType() == "text") {
             // Write the stress state details
             stress_state.write_ascii(stress_index_outfile);
             stress_index_outfile.flush();
-            
+
             // Write the stress details
             stress.write_ascii(stress_outfile);
             stress_outfile.flush();
         } else if (getStressOutfileType() == "hdf5") {
             // Write the stress state details
             stress_state.append_stress_state_hdf5(stress_data_file);
-            
+
             // Write the stress details
             stress.append_stress_hdf5(stress_data_file);
-            
+
         }
-        
+
         // use delete [] for arrays:
         if (isRootNode()) {
             delete [] counts;
@@ -190,38 +193,38 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
             delete all_shear;
         }
     }
-    
+
 #else
     // Single processor output
-    
+
     stress_state.setYear(getYear());
     stress_state.setEventNum(event_num);
     stress_state.setStartEndRecNums(num_stress_recs, num_stress_recs+numGlobalBlocks());
-    
+
     for (unsigned int i=0; i<numGlobalBlocks(); ++i) {
         stress.add_stress_entry(i, shear_stress[i], normal_stress[i], slip_deficit[i]);
     }
-    
+
     num_stress_recs += numGlobalBlocks();
-    
+
     if (getStressOutfileType() == "text") {
         // Write the stress state details
         stress_state.write_ascii(stress_index_outfile);
         stress_index_outfile.flush();
-        
+
         // Write the stress details
         stress.write_ascii(stress_outfile);
         stress_outfile.flush();
     } else if (getStressOutfileType() == "hdf5") {
         // Write the stress state details
         stress_state.append_stress_state_hdf5(stress_data_file);
-        
+
         // Write the stress details
         stress.append_stress_hdf5(stress_data_file);
     }
-    
+
 #endif
-    
+
 }
 
 /*!
@@ -300,10 +303,10 @@ void Simulation::open_stress_hdf5_file(const std::string &hdf5_file_name) {
 
     // Schultz: I've changed this methodology. Now instead of writing to HDF5 in parallel,
     //     we consolidate the info from all procs then write from the root.
-//#ifdef HDF5_IS_PARALLEL
-//    H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL);
-//#endif
-    
+    //#ifdef HDF5_IS_PARALLEL
+    //    H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL);
+    //#endif
+
     // Create the data file, overwriting any old files
     stress_data_file = H5Fcreate(hdf5_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
 

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -71,6 +71,7 @@ Simulation::Simulation(int argc, char **argv) : SimFramework(argc, argv) {
 void Simulation::output_stress(quakelib::UIndex event_num) {
     quakelib::ModelStress       stress;
     quakelib::ModelStressState  stress_state;
+    unsigned int                gid;
 
     if (getStressOutfileType() == "") return;
 
@@ -79,12 +80,12 @@ void Simulation::output_stress(quakelib::UIndex event_num) {
     //stress_state.setSweepNum(sweep_num);
     stress_state.setStartEndRecNums(num_stress_recs, num_stress_recs+numGlobalBlocks());
 
-    // Store stress values
+    // Communicate all values between nodes
+
+
     for (unsigned int i=0; i<numGlobalBlocks(); ++i) {
         // TODO: Figure this out for multi-proc
-        if (isLocalBlockID(i)) {
-            stress.add_stress_entry(i, shear_stress[i], normal_stress[i], slip_deficit[i]);
-        }
+        stress.add_stress_entry(i, shear_stress[i], normal_stress[i], slip_deficit[i]);
     }
 
     num_stress_recs += numGlobalBlocks();

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -68,7 +68,7 @@ Simulation::Simulation(int argc, char **argv) : SimFramework(argc, argv) {
     }
 }
 
-void Simulation::output_stress(quakelib::UIndex event_num, quakelib::UIndex sweep_num) {
+void Simulation::output_stress(quakelib::UIndex event_num) {
     quakelib::ModelStress       stress;
     quakelib::ModelStressState  stress_state;
 
@@ -81,7 +81,7 @@ void Simulation::output_stress(quakelib::UIndex event_num, quakelib::UIndex swee
 
     // Store stress values
     for (unsigned int i=0; i<numGlobalBlocks(); ++i) {
-        stress.add_stress_entry(i, shear_stress[i], normal_stress[i]);
+        stress.add_stress_entry(i, shear_stress[i], normal_stress[i], slip_deficit[i]);
     }
 
     num_stress_recs += numGlobalBlocks();

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -323,6 +323,12 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
         void partitionBlocks(void);
 
         void output_stress(quakelib::UIndex event_num);
+        
+#ifdef HDF5_FOUND
+        hid_t getStressDataFileHandle(void) const {
+            return stress_data_file;
+        }
+#endif
 
     private:
 #ifdef DEBUG

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -191,7 +191,7 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
         double getSelfStresses(const BlockID gid) const {
             return self_shear[gid] - friction[gid]*self_normal[gid];
         };
-        
+
         //! Get the area for the section in square meters.
         double getSectionArea(const SectionID sid) const {
             return section_areas.find(sid)->second;
@@ -204,28 +204,28 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
                 section_areas.insert(std::make_pair(sid, new_area));
             }
         };
-        
+
         //! Compute the dynamic stress drop from the current event size for element gid.
         double computeDynamicStressDrop(const BlockID gid, const double current_event_area) const {
             double fault_area, fault_length, fault_width, char_slip;
             double char_magnitude, R, nu, dynamicStressDrop;
-            
+
             // Fault wise data
             fault_area = getSectionArea(getBlock(gid).getSectionID());
             fault_length = getSectionLength(getBlock(gid).getSectionID());
             fault_width = fault_area/fault_length;
             R = sqrt(fault_length*fault_length + fault_width*fault_width);
             nu = 0.5*getBlock(gid).lame_lambda()/(getBlock(gid).lame_mu() + getBlock(gid).lame_lambda());
-            
+
             // Get current expected slip from the current event area
             char_magnitude = 4.0+log10(current_event_area*1e-6) + stressDropFactor();
             char_slip = pow(10, (3.0/2.0)*(char_magnitude+10.7))/(1e7*getBlock(gid).lame_mu()*current_event_area);
-            
+
             dynamicStressDrop = -2*getBlock(gid).lame_mu()*char_slip*( (1-nu)*fault_length/fault_width + fault_width/fault_length )/( (1-nu)*M_PI*R );
-            
+
             return dynamicStressDrop;
         };
-        
+
         //! Get the length for the section in meters.
         double getSectionLength(const SectionID sid) const {
             return section_lengths.find(sid)->second;
@@ -248,7 +248,7 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
             stress_drop[gid] = new_stress_drop;
             calcFriction(gid);
         };
-        
+
         //! Get the max stress drop for this block in Pascals.
         double getMaxStressDrop(const BlockID gid) const {
             return max_stress_drop[gid];

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -158,6 +158,13 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
             return friction[gid];
         }
 
+//        void setFriction(const BlockID gid, const double coefficient) {
+//            // Schultz: Cannot let friction decrease with increasing depth.
+//            // Instead lets prescribe a coefficient.
+//            // TODO: Add friction file reading so we can specify coeff. per block
+//            friction[gid] = coefficient;
+//        }
+
         //! Whether the block experienced static friction failure.
         //! This occurs if the Coulomb failure function goes over 0.
         bool cffFailure(const BlockID gid) const {

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -218,7 +218,7 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
             nu = 0.5*getBlock(gid).lame_lambda()/(getBlock(gid).lame_mu() + getBlock(gid).lame_lambda());
             
             // Get current expected slip from the current event area
-            char_magnitude = 4.07+0.98*log10(current_event_area*1e-6) + stressDropFactor();
+            char_magnitude = 4.0+log10(current_event_area*1e-6) + stressDropFactor();
             char_slip = pow(10, (3.0/2.0)*(char_magnitude+10.7))/(1e7*getBlock(gid).lame_mu()*current_event_area);
             
             dynamicStressDrop = -2*getBlock(gid).lame_mu()*char_slip*( (1-nu)*fault_length/fault_width + fault_width/fault_length )/( (1-nu)*M_PI*R );
@@ -322,7 +322,7 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
 
         void partitionBlocks(void);
 
-        void output_stress(quakelib::UIndex event_num, quakelib::UIndex sweep_num);
+        void output_stress(quakelib::UIndex event_num);
 
     private:
 #ifdef DEBUG

--- a/src/io/EventOutput.cpp
+++ b/src/io/EventOutput.cpp
@@ -201,6 +201,18 @@ void EventOutput::finish(SimFramework *_sim) {
 
         if (res < 0) exit(-1);
     }
+        
+    // Schultz: Need to explicitly close the HDF5 stress output file
+//    if (sim->isRootNode()) {
+//        hid_t stress_data_file = sim->getStressDataFileHandle();
+//
+//        herr_t res = H5Fclose(stress_data_file);
+//
+//        if (res < 0) exit(-1);
+//        
+//        sim->console() << "# Closed hdf5 stress out file, hid_t = " << stress_data_file << std::endl;
+//        
+//    }
 
 #endif
 

--- a/src/io/ReadModelFile.cpp
+++ b/src/io/ReadModelFile.cpp
@@ -40,8 +40,6 @@ void ReadModelFile::init(SimFramework *_sim) {
     Simulation                  *sim = static_cast<Simulation *>(_sim);
     std::string                 file_name, file_type, stress_filename, stress_file_type, stress_index_filename;
     quakelib::ModelWorld        world;
-    quakelib::ModelStressSet    stress_set;
-    quakelib::ModelStress       stress;
     quakelib::siterator         sit;
     quakelib::eiterator         eit;
     int                         err;
@@ -60,38 +58,10 @@ void ReadModelFile::init(SimFramework *_sim) {
         return;
     }
 
-    stress_file_type = sim->getStressInfileType();
-    stress_filename = sim->getStressInfile();
-    stress_index_filename = sim->getStressIndexInfile();
-    
-    if (stress_filename != "" && stress_file_type != "" && stress_index_filename != "") {
-        // Read the stress input file for initial stress conditions
-        if (stress_file_type == "text") {
-            err |= stress_set.read_file_ascii(stress_index_filename, stress_filename);
-        } else if (stress_file_type == "hdf5") {
-            // TODO: Schultz, add hdf5 reading
-            sim->errConsole() << "ERROR: only text files supported right now " << file_type << std::endl;
-            return;
-        } else {
-            sim->errConsole() << "ERROR: unknown file type " << file_type << std::endl;
-            return;
-        }
-    }
-    
-    
     // If there was an error then exit
     if (err) {
         sim->errConsole() << "ERROR: could not read file " << file_name << std::endl;
         return;
-    }
-    
-    // Schultz: Currently we only support a single stress state. We may want to keep writing stress
-    // states every N events, then just load the last event saved in the stress state file.
-    if (stress_filename != "" && stress_file_type != "" && stress_index_filename != "" && !err) {
-        // Grab the stress values of the first (only) stress state
-        stress = stress_set[0].stresses();
-        // Also set the sim year to the year the stresses were saved
-        sim->setYear(stress_set[0].getYear());
     }
 
     // Convert input world to simulation elements
@@ -125,14 +95,8 @@ void ReadModelFile::init(SimFramework *_sim) {
         new_block.setSectionID(eit->section_id());    // TODO: add sections?
 
         BlockID bid = sim->addBlock(new_block);
+        
+        sim->setInitShearNormalStress(bid, 0, 0);
 
-        // If given an initial stress state, set those stresses
-        if (stress_filename != "" && stress_file_type != "" && stress_index_filename != "") {
-            assert(stress[bid]._element_id == bid);
-            sim->console() << bid << "  "  << stress[bid]._shear_stress << "  " << stress[bid]._normal_stress << "  " << std::endl;
-            sim->setInitShearNormalStress(bid, stress[bid]._shear_stress, stress[bid]._normal_stress);
-        } else {
-            sim->setInitShearNormalStress(bid, 0, 0);
-        }
     }
 }

--- a/src/io/ReadModelFile.cpp
+++ b/src/io/ReadModelFile.cpp
@@ -95,7 +95,7 @@ void ReadModelFile::init(SimFramework *_sim) {
         new_block.setSectionID(eit->section_id());    // TODO: add sections?
 
         BlockID bid = sim->addBlock(new_block);
-        
+
         sim->setInitShearNormalStress(bid, 0, 0);
 
     }

--- a/src/misc/GreensFunctions.cpp
+++ b/src/misc/GreensFunctions.cpp
@@ -84,6 +84,7 @@ void GreensFuncCalcStandard::CalculateGreens(Simulation *sim) {
     for (int r=0; r<sim->numLocalBlocks(); ++r) {
         for (int c=0; c<num_blocks; ++c) {
             int global_r = sim->getGlobalBID(r);
+
             //// Schultz, excluding zero slip rate elements from sim by setting Greens to zero
             if (sim->getBlock(global_r).slip_rate()==0  ||  sim->getBlock(c).slip_rate()==0) {
                 sim->setGreens(global_r, c, 0, 0);

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -737,9 +737,11 @@ void RunEvent::processStaticFailure(Simulation *sim) {
     // Write stress state to the stress output file if we're
     // at a multiple of N_events = sim->getStressOutInterval().
     unsigned int evnum = sim->getCurrentEvent().getEventNumber();
-    if (evnum >= sim->getStressOutInterval() && evnum%sim->getStressOutInterval() == 0 && sim->isRootNode()) {
+    if (evnum >= sim->getStressOutInterval() && evnum%sim->getStressOutInterval() == 0) {
         sim->output_stress(sim->getCurrentEvent().getEventNumber());
-        sim->console() << std::endl << "--- Writing sim stress state to file ---" << std::endl << std::flush;
+        if (sim->isRootNode()) {
+        sim->console() << std::endl << "--- Writing sim stress state to file after event " << sim->getCurrentEvent().getEventNumber() << " ---" << std::endl << std::flush;
+        }
     }
     
 }

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -716,10 +716,6 @@ void RunEvent::processStaticFailure(Simulation *sim) {
         sweep_num++;
     }
 
-    //
-    // output_stress() for final item in list.
-    //sim->output_stress(sim->getCurrentEvent().getEventNumber(), sweep_num);
-
     // Set the completed list as the sweep list for the entire event
     sim->collectEventSweep(event_sweeps);
     sim->getCurrentEvent().setSweeps(event_sweeps);
@@ -739,9 +735,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
     unsigned int evnum = sim->getCurrentEvent().getEventNumber();
     if (evnum >= sim->getStressOutInterval() && evnum%sim->getStressOutInterval() == 0) {
         sim->output_stress(sim->getCurrentEvent().getEventNumber());
-        if (sim->isRootNode()) {
         sim->console() << std::endl << "--- Writing sim stress state to file after event " << sim->getCurrentEvent().getEventNumber() << " ---" << std::endl << std::flush;
-        }
     }
     
 }

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -690,7 +690,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             //
             // yoder: as per request by KS, change std::isnan() --> std::isnan(); std::isnan() appears to throw an error on some platforms.
             // Eric: Probably don't need this if check
-            if (std::isnan(s_it->_shear_final) and std::isnan(s_it->_normal_final)) {
+            if (isnan(s_it->_shear_final) and isnan(s_it->_normal_final)) {
                 // note: the stress entries are initialized with nan values, but if there are cases where non nan values need to be updated,
                 // this logic should be revisited.
                 event_sweeps.setFinalStresses(sweep_num,

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -57,7 +57,7 @@ void RunEvent::markBlocks2Fail(Simulation *sim, const FaultID &trigger_fault) {
 void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &sweeps) {
     quakelib::ElementIDSet::iterator    fit;
     double                              slip, stress_drop;
-    
+
 
     // For each block that fails in this sweep, calculate how much it slips
     for (fit=local_failed_elements.begin(); fit!=local_failed_elements.end(); ++fit) {
@@ -69,7 +69,7 @@ void RunEvent::processBlocksOrigFail(Simulation *sim, quakelib::ModelSweeps &swe
             // Even if we're doing dynamic stress drops, they've already been adjusted before this method
             // has been called.
             stress_drop = sim->getStressDrop(gid) - sim->getCFF(gid);
-            
+
             // Slip is in m
             slip = (stress_drop/sim->getSelfStresses(gid));
 
@@ -179,6 +179,7 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
         quakelib::ElementIDSet current_blocks;
         quakelib::ElementIDSet::const_iterator cit;
         BlockIDProcMapping::const_iterator  bit;
+
         // Compute the current event area
         // Add in global_failed_elements
         for (bit=global_failed_elements.begin(); bit!=global_failed_elements.end(); ++bit) {
@@ -188,6 +189,7 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
                 current_blocks.insert(bit->first);
             }
         }
+
         // Also add in the area from the secondary failed elements
         for (bit=global_secondary_id_list.begin(); bit!=global_secondary_id_list.end(); ++bit) {
             // Avoid double counting
@@ -196,7 +198,7 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
                 current_blocks.insert(bit->first);
             }
         }
-        
+
         for (cit=current_blocks.begin(); cit!=current_blocks.end(); ++cit) {
             if (current_event_area < sim->getSectionArea(sim->getBlock(*cit).getSectionID())) {
                 // If the current area is smaller than the section area, scale the stress drop
@@ -228,9 +230,9 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
                 A[i*num_global_failed+n] -= sim->getFriction(*it)*sim->getGreenNormal(*it, jt->first);
             }
         }
-        
+
         ///// Schultz:
-        // Even if we are doing dynamic stress drops, they've already been set. Check processStaticFailure() and 
+        // Even if we are doing dynamic stress drops, they've already been set. Check processStaticFailure() and
         // the beginning of this method
         b[i] = sim->getStressDrop(*it) - sim->getCFF(*it);
     }
@@ -508,7 +510,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
         sim->distributeBlocks(local_failed_elements, global_failed_elements);
         //sim->barrier(); // yoder: (debug)
         //
-        
+
         // Schultz: now that we know how many elements are involved, assign dynamic stress drops
         if (sim->doDynamicStressDrops()) {
             double current_event_area = 0.0;
@@ -516,6 +518,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             quakelib::ElementIDSet current_blocks;
             quakelib::ElementIDSet::const_iterator cit;
             BlockIDProcMapping::const_iterator  bit;
+
             // Compute the current event area
             // Add in global_failed_elements
             for (bit=global_failed_elements.begin(); bit!=global_failed_elements.end(); ++bit) {
@@ -525,7 +528,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
                     current_blocks.insert(bit->first);
                 }
             }
-            
+
             for (cit=current_blocks.begin(); cit!=current_blocks.end(); ++cit) {
                 if (current_event_area < sim->getSectionArea(sim->getBlock(*cit).getSectionID())) {
                     // If the current area is smaller than the section area, scale the stress drop
@@ -536,7 +539,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
                 }
             }
         }
-        
+
         // Process the blocks that failed.
         // note: setInitStresses() called in processBlocksOrigFail().
         // note: processBlocksOrigFail() is entirely local (no MPI).
@@ -565,18 +568,18 @@ void RunEvent::processStaticFailure(Simulation *sim) {
         // and set non-neighbors to double that. But that seems unphysical. Until verified, it's removed.
         ////////////
         // Set dynamic triggering on for any blocks neighboring blocks that slipped in the last sweep
-//        for (it=sim->begin(); it!=sim->end(); ++it) {
-//            BlockID gid = it->getBlockID();
-//
-//            // Add block neighbors if the block has slipped
-//            if (sim->getFailed(gid)) {
-//                nbr_start_end = sim->getNeighbors(gid);
-//
-//                for (nit=nbr_start_end.first; nit!=nbr_start_end.second; ++nit) {
-//                    loose_elements.insert(*nit);
-//                }
-//            }
-//        }
+        //        for (it=sim->begin(); it!=sim->end(); ++it) {
+        //            BlockID gid = it->getBlockID();
+        //
+        //            // Add block neighbors if the block has slipped
+        //            if (sim->getFailed(gid)) {
+        //                nbr_start_end = sim->getNeighbors(gid);
+        //
+        //                for (nit=nbr_start_end.first; nit!=nbr_start_end.second; ++nit) {
+        //                    loose_elements.insert(*nit);
+        //                }
+        //            }
+        //        }
 
         //
         // Calculate the CFFs based on the stuck blocks
@@ -719,7 +722,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
     // Set the completed list as the sweep list for the entire event
     sim->collectEventSweep(event_sweeps);
     sim->getCurrentEvent().setSweeps(event_sweeps);
-    
+
     // Schultz: Dynamic stress drops
     // Now that the event is over, reset the stress drops to the inter-event values
     if (sim->doDynamicStressDrops()) {
@@ -728,16 +731,17 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             sim->setStressDrop(gid, sim->getMaxStressDrop(gid));
         }
     }
-    
-    
+
+
     // Write stress state to the stress output file if we're
     // at a multiple of N_events = sim->getStressOutInterval().
     unsigned int evnum = sim->getCurrentEvent().getEventNumber();
+
     if (evnum >= sim->getStressOutInterval() && evnum%sim->getStressOutInterval() == 0) {
         sim->output_stress(sim->getCurrentEvent().getEventNumber());
         sim->console() << std::endl << "--- Writing sim stress state to file after event " << sim->getCurrentEvent().getEventNumber() << " ---" << std::endl << std::flush;
     }
-    
+
 }
 
 /*!

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -79,7 +79,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
             }
             
             // Schultz: Currently we just load the last event saved in the stress state file.
-            assertThrow(stress_set.size() == sim->numGlobalBlocks(), "Did not read the correct number of blocks from stress file.");
+            assertThrow(stress_set[stress_set.size()-1].getNumStressRecords() == sim->numGlobalBlocks(), "Did not read the correct number of blocks from stress file.");
             stress = stress_set[stress_set.size()-1].stresses();
             // Also set the sim year to the year the stresses were saved
             sim->setYear(stress_set[stress_set.size()-1].getYear());
@@ -95,10 +95,11 @@ void UpdateBlockStress::init(SimFramework *_sim) {
                 sim->setUpdateField(stress[i]._element_id, stress[i]._slip_deficit);
             }
             
-            // Broadcast the slip deficits to all nodes
-            sim->broadcastUpdateField();
         }
     }
+    
+    // Broadcast the slip deficits from root node to all nodes
+    sim->broadcastUpdateField();
     
     // And update the slip deficit on each process to take this into account
     for (gid=0; gid<sim->numGlobalBlocks(); ++gid) {

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -28,7 +28,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
     BlockList::iterator nt;
     BlockID             gid;
     SectionID           sid;
-    int                 lid;
+    int                 lid, i;
     bool                err;
     double              stress_drop;
     double rho = 2700.0;      // density of rock in kg m^-3
@@ -75,11 +75,12 @@ void UpdateBlockStress::init(SimFramework *_sim) {
         sim->setYear(stress_set[stress_set.size()-1].getYear());
         sim->console() << "--- Setting initial stresses from file, starting new sim at year " << sim->getYear() << " ---" << std::endl;
     
-        // If given an initial stress state, set those stresses
-        for (gid=0; gid<sim->numGlobalBlocks(); ++gid) {
-            assert(stress[gid]._element_id == gid);
-            sim->setInitShearNormalStress(gid, stress[gid]._shear_stress, stress[gid]._normal_stress);
-            sim->setSlipDeficit(gid, stress[gid]._slip_deficit);
+        // If given an initial stress state, set those stresses and slip deficits.
+        // Schultz: The slip deficit is really the only information used to start the sim, as we
+        // recalculate stresses at the end of this init() based on slip deficits.
+        for (i=0; i<stress.size(); ++i) {
+            sim->setInitShearNormalStress(stress[i]._element_id, stress[i]._shear_stress, stress[i]._normal_stress);
+            sim->setSlipDeficit(stress[i]._element_id, stress[i]._slip_deficit);
         }
     }
 

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -82,8 +82,12 @@ void UpdateBlockStress::init(SimFramework *_sim) {
             assertThrow(stress_set[stress_set.size()-1].getNumStressRecords() == sim->numGlobalBlocks(), "Did not read the correct number of blocks from stress file.");
             stress = stress_set[stress_set.size()-1].stresses();
             // Also set the sim year to the year the stresses were saved
-            sim->setYear(stress_set[stress_set.size()-1].getYear());
-            sim->console() << "--- Setting initial stresses from file, starting new sim at year " << sim->getYear() << " ---" << std::endl;
+            ///// SCHULTZ: For some reason, when we read in the stresses and set the start year to be non-zero,
+            // when the simulation executes vc_sim->finish() and tries to stop all the timers, it is unable to 
+            // stop total_timer and just freezes. For now I will handle this with PyVQ, modifying the years when
+            // one specifies that you want to paste together multiple event files.
+            //sim->setYear(stress_set[stress_set.size()-1].getYear());
+            //sim->console() << "--- Setting initial stresses from file, starting new sim at year " << sim->getYear() << " ---" << std::endl;
         
             // If given an initial stress state, set those stresses and slip deficits.
             // Schultz: The slip deficit is really the only information used to start the sim, as we
@@ -178,6 +182,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
     // and transfer stress drop values between nodes later
     for (lid=0; lid<sim->numLocalBlocks(); ++lid) {
         gid = sim->getGlobalBID(lid);
+        
         //
         // TODO: check if this negative sign is warranted and not double counted
         depth = fabs(sim->getBlock(gid).center()[2]);  // depth of block center in m
@@ -299,11 +304,11 @@ void UpdateBlockStress::init(SimFramework *_sim) {
     stressRecompute();
     
 //    Debug output
-    if (sim->isRootNode()) {
-        for (gid=0; gid<sim->numGlobalBlocks(); ++gid) {
-            std::cout << gid << "  " << sim->getShearStress(gid) << "  " << sim->getNormalStress(gid) << "  " << sim->getSlipDeficit(gid) <<std::endl;
-        }
-    }
+//    if (sim->isRootNode()) {
+//        for (gid=0; gid<sim->numGlobalBlocks(); ++gid) {
+//            std::cout << gid << "  " << sim->getShearStress(gid) << "  " << sim->getNormalStress(gid) << "  " << sim->getSlipDeficit(gid) <<std::endl;
+//        }
+//    }
 
 }
 

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -52,7 +52,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
     std::string stress_file_type = sim->getStressInfileType();
     std::string stress_filename = sim->getStressInfile();
     std::string stress_index_filename = sim->getStressIndexInfile();
-    
+
     if (stress_filename != "" && stress_file_type != "" && stress_index_filename != "") {
         
         if (stress_file_type == "text") {
@@ -75,8 +75,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
         sim->console() << "--- Setting intial stresses from file, starting new sim at year " << sim->getYear() << " ---" << std::endl;
     
         // If given an initial stress state, set those stresses
-        for (lid=0; lid<sim->numLocalBlocks(); ++lid) {
-            gid = sim->getGlobalBID(lid);
+        for (gid=0; gid<sim->numGlobalBlocks(); ++gid) {
             assert(stress[gid]._element_id == gid);
             sim->setInitShearNormalStress(gid, stress[gid]._shear_stress, stress[gid]._normal_stress);
             sim->setSlipDeficit(gid, stress[gid]._slip_deficit);
@@ -170,7 +169,6 @@ void UpdateBlockStress::init(SimFramework *_sim) {
         sim->setShearStress(gid, sim->getInitShearStress(gid));
         //printf("**Degbug(%d): normal[%d]\n", getpid(), gid);
         sim->setNormalStress(gid, sim->getInitNormalStress(gid));
-        std::cout << gid << "  " << sim->getShearStress(gid) << "  " << sim->getNormalStress(gid) <<std::endl;
 
         // Set the stress drop based on the Greens function calculations
         if (sim->computeStressDrops()) {

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -222,7 +222,7 @@ void UpdateBlockStress::init(SimFramework *_sim) {
         }
 
         // Initialize element slips to equilibrium position, slip=0
-        // Unless we are reading in a stress input file, then we have already set the slip deficit in ReadModelFile.cpp
+        // Unless we are reading in a stress input file, then we have already set the slip deficit higher up in this method
         if (sim->getStressInfile() == "" && sim->getStressIndexInfile() == "") sim->setSlipDeficit(gid, 0);
 
         if (sim->isLocalBlockID(gid)) {

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -68,10 +68,9 @@ void UpdateBlockStress::init(SimFramework *_sim) {
         
         // Schultz: Currently we only support a single stress state. We may want to keep writing stress
         // states every N events, then just load the last event saved in the stress state file.
-        // Grab the stress values of the first (only) stress state
-        stress = stress_set[0].stresses();
+        stress = stress_set[stress_set.size()-1].stresses();
         // Also set the sim year to the year the stresses were saved
-        sim->setYear(stress_set[0].getYear());
+        sim->setYear(stress_set[stress_set.size()-1].getYear());
         sim->console() << "--- Setting intial stresses from file, starting new sim at year " << sim->getYear() << " ---" << std::endl;
     
         // If given an initial stress state, set those stresses


### PR DESCRIPTION
Added the ability to output/input the stress state for a simulation (hdf5 and text). Relevant simulation parameters are:

sim.file.input_stress
sim.file.input_stress_index (only required for text file I/O)
sim.file.input_stress_type
sim.file.output_stress
sim.file.output_stress_index (only required for text file I/O)
sim.file.output_stress_type
sim.file.output_stress_num_events (number of events required before stress output)

The relevant PyVQ parameters (for combining two event files, one that saved output and a second that began from the first sim's state output). Currently this only works for hdf5 files. Parameters are:

--event_file (first file that had the stress output after some number of events)
--stress_file (the stress output file that the first simulation wrote)
--combine_file (the second sim that began from the state saved in stress_file

