### PR TITLE
Using math.h for isnan, may not compile on some machines

### DIFF
--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -693,7 +693,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             //
             // yoder: as per request by KS, change std::isnan() --> std::isnan(); std::isnan() appears to throw an error on some platforms.
             // Eric: Probably don't need this if check
-            if (std::isnan(s_it->_shear_final) and std::isnan(s_it->_normal_final)) {
+            if (isnan(s_it->_shear_final) and isnan(s_it->_normal_final)) {
                 // note: the stress entries are initialized with nan values, but if there are cases where non nan values need to be updated,
                 // this logic should be revisited.
                 event_sweeps.setFinalStresses(sweep_num,


### PR DESCRIPTION
This change should make VQ build on the CIG build-test system Jenkins. This may be only a temp fix, as it still may not compile on some to-be-determined system due to issues with the "isnan" function being supplied by math.h, and the "std::isnan" function being supplied by cmath.