### PR TITLE
Mesher bug fixes and default behavior change

### DIFF
--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -479,7 +479,8 @@ void quakelib::ModelWorld::create_section(std::vector<unsigned int> &unused_trac
 
     // Create a spline with the trace points
     for (i=0; i<num_trace_pts; ++i) {
-        Vec<3> pt = conv.convert2xyz(trace.at(i).pos());
+    	Vec<3> pt = conv.convert2xyz(trace.at(i).pos());
+        //Vec<3> pt = conv.yxz2xyz(trace.at(i).pos()); //Use for importing trace in (y, x) halfspace coords
         spline.add_point(pt);
         unused_trace_pts.insert(i);
     }

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -423,6 +423,7 @@ class TraceSpline {
             // an element greater than our target size
             double cur_dist = t * _spline_len;
 
+            /*// Wilson: Correcting indexing for horizontal size
             while (ind+1 < _pts.size() && start_pt.dist(_pts.at(ind+1)) < elem_size) {
                 ind++;
 
@@ -430,7 +431,15 @@ class TraceSpline {
                 else cur_dist += elem_size;
 
                 inner_t = 0;
-            }
+            }*/
+            while (ind < _pts.size()-1 && start_pt.dist(_pts.at(ind+1)) < elem_size) {
+
+            	if (ind < _point_dists.size()-1) cur_dist += (1-inner_t) * _point_dists.at(ind);
+				else cur_dist = (t * _spline_len) + elem_size;
+
+            	ind++;
+				inner_t = 0;
+			}
 
             // If we're past the end of the trace, return our best guess
             // for t based on the size of the last segment
@@ -502,7 +511,8 @@ void quakelib::ModelWorld::create_section(std::vector<unsigned int> &unused_trac
         while (cur_t < 1) {
             next_t = spline.advance_element(cur_t, cur_elem_size_guess);
 
-            if (next_t < 1) {
+            //Wilson: changed this condition to <= to get last column of elements for perfect fit traces
+            if (next_t <= 1) {
                 sum_t += next_t-cur_t;
                 elem_count++;
                 cur_t = next_t;

--- a/quakelib/src/QuakeLibUtil.cpp
+++ b/quakelib/src/QuakeLibUtil.cpp
@@ -186,6 +186,16 @@ quakelib::Vec<3> quakelib::Conversion::convert2xyz(const LatLonDepth &in_pt) con
 }
 #endif
 
+quakelib::Vec<3> quakelib::Conversion::yxz2xyz(const LatLonDepth &in_pt) const {
+    double  new_vals[3];
+
+    new_vals[0] = in_pt.lon();
+	new_vals[1] = in_pt.lat();
+	new_vals[2] = in_pt.altitude();
+
+    return Vec<3>(new_vals);
+}
+
 quakelib::VectorList quakelib::Conversion::convertArray2xyz(const FloatList &lats, const FloatList &lons) const {
     quakelib::VectorList conversions;
 

--- a/quakelib/src/QuakeLibUtil.h
+++ b/quakelib/src/QuakeLibUtil.h
@@ -384,10 +384,9 @@ namespace quakelib {
             LatLonDepth(void) : _lat(std::numeric_limits<double>::quiet_NaN()), _lon(std::numeric_limits<double>::quiet_NaN()), _altitude(std::numeric_limits<double>::quiet_NaN()) {};
             //! Constructor with specified latitude and longitude. Altitude defaults to 0 unless specified.
             LatLonDepth(const double &lat, const double &lon, const double &altitude=0) throw(std::invalid_argument) : _lat(lat), _lon(lon), _altitude(altitude) {
-                /*if (fabs(lat)>90) throw std::invalid_argument("LatLonDepth::lat must be in [-90,90].");
+                if (fabs(lat)>90) throw std::invalid_argument("LatLonDepth::lat must be in [-90,90].");
 
                 if (fabs(lon)>180) throw std::invalid_argument("LatLonDepth::lon must be in [-180,180].");
-                 */
             }
 
             //! Get the latitude in degrees of this point.

--- a/quakelib/src/QuakeLibUtil.h
+++ b/quakelib/src/QuakeLibUtil.h
@@ -384,9 +384,10 @@ namespace quakelib {
             LatLonDepth(void) : _lat(std::numeric_limits<double>::quiet_NaN()), _lon(std::numeric_limits<double>::quiet_NaN()), _altitude(std::numeric_limits<double>::quiet_NaN()) {};
             //! Constructor with specified latitude and longitude. Altitude defaults to 0 unless specified.
             LatLonDepth(const double &lat, const double &lon, const double &altitude=0) throw(std::invalid_argument) : _lat(lat), _lon(lon), _altitude(altitude) {
-                if (fabs(lat)>90) throw std::invalid_argument("LatLonDepth::lat must be in [-90,90].");
+                /*if (fabs(lat)>90) throw std::invalid_argument("LatLonDepth::lat must be in [-90,90].");
 
                 if (fabs(lon)>180) throw std::invalid_argument("LatLonDepth::lon must be in [-180,180].");
+                 */
             }
 
             //! Get the latitude in degrees of this point.
@@ -467,6 +468,9 @@ namespace quakelib {
 
             //! Convert the specified point to a Cartesian coordinate using the base as (0,0,0).
             Vec<3> convert2xyz(const LatLonDepth &in_pt) const;
+
+            //! Used for reading in km-space trace files.
+			Vec<3> yxz2xyz(const LatLonDepth &in_pt) const;
 
             //! Convert the specified Cartesian coordinate to latitude/longitude using the base as (0,0,0).
             LatLonDepth convert2LatLon(const Vec<3> &in_pt) const;

--- a/src/mesher.cpp
+++ b/src/mesher.cpp
@@ -153,8 +153,11 @@ void print_usage(int argc, char **argv) {
     std::cerr << "-d, --delete_unused" << std::endl;
     std::cerr << "\tDelete unused vertices after importing files." << std::endl;
     std::cerr << "-r, --resize_trace_elements" << std::endl;
+    std::cerr << "\tTurns off resizing of elements generated on traces." << std::endl;
+    /*//Wilson: changed default behavior to resize elements.
     std::cerr << "\tResize elements generated on traces to better match fault length." << std::endl;
     std::cerr << "\tThis will only decrease and at most halve the element size." << std::endl;
+	*/
 
     std::cerr << std::endl;
     std::cerr << "FILE IMPORT" << std::endl;
@@ -201,7 +204,8 @@ int main (int argc, char **argv) {
     int                         ch, res;
     unsigned int                i, n, j, num_trace_files;
 
-    arg_error = delete_unused = merge_duplicate_vertices = resize_trace_elements = false;
+    arg_error = delete_unused = merge_duplicate_vertices = false;
+    resize_trace_elements = true;
     eqsim_geom_in_file = eqsim_fric_in_file = eqsim_cond_in_file = "";
     eqsim_geom_out_file = eqsim_fric_out_file = eqsim_cond_out_file = "";
 
@@ -216,7 +220,7 @@ int main (int argc, char **argv) {
                 break;
 
             case 'r':
-                resize_trace_elements = true;
+                resize_trace_elements = false;
                 break;
 
             case 's':


### PR DESCRIPTION
Mesher now correctly includes last column of elements for perfect-fit element sizes.  Default behavior is now to resize elements, which can be turned off with "-r" option.