### PR TITLE
Fault model I/O and mesher updates for Stress Drops

### DIFF
--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -2645,6 +2645,12 @@ if __name__ == "__main__":
         for i, event_set in enumerate(events):
             FrequencyMagnitudePlot().plot(fig, i, event_set, args.event_file[i].split("events_")[-1].split("/")[-1], UCERF2=UCERF2, b1=b1)
         plt.legend(loc='best', fontsize=8)
+        if args.min_magnitude is not None and args.max_magnitude is not None:
+            plt.xlim(args.min_magnitude, args.max_magnitude)
+        elif args.min_magnitude is not None:
+            plt.xlim(args.min_magnitude, plt.xlim()[1])
+        elif args.max_magnitude is not None:
+            plt.xlim(plt.xlim()[0], args.max_magnitude)
         plt.savefig(filename,dpi=100)
         sys.stdout.write("Plot saved: {}\n".format(filename))
     if args.plot_mag_rupt_area:
@@ -2653,6 +2659,12 @@ if __name__ == "__main__":
         filename = SaveFile().event_plot(args.event_file, "mag_rupt_area", args.min_magnitude, args.min_year, args.max_year, args.combine_file)
         for i, event_set in enumerate(events):
             MagnitudeRuptureAreaPlot().plot(fig, i, event_set, args.event_file[i].split("events_")[-1].split("/")[-1], WC94=args.wc94, leonard=args.leonard)
+        if args.min_magnitude is not None and args.max_magnitude is not None:
+            plt.xlim(args.min_magnitude, args.max_magnitude)
+        elif args.min_magnitude is not None:
+            plt.xlim(args.min_magnitude, plt.xlim()[1])
+        elif args.max_magnitude is not None:
+            plt.xlim(plt.xlim()[0], args.max_magnitude)
         plt.legend(loc='best', fontsize=8)
         plt.savefig(filename,dpi=100)
         sys.stdout.write("Plot saved: {}\n".format(filename))
@@ -2662,6 +2674,12 @@ if __name__ == "__main__":
         filename = SaveFile().event_plot(args.event_file, "mag_mean_slip", args.min_magnitude, args.min_year, args.max_year, args.combine_file)
         for i, event_set in enumerate(events):
             MagnitudeMeanSlipPlot().plot(fig, i, event_set, args.event_file[i].split("events_")[-1].split("/")[-1], WC94=args.wc94, leonard=args.leonard)
+        if args.min_magnitude is not None and args.max_magnitude is not None:
+            plt.xlim(args.min_magnitude, args.max_magnitude)
+        elif args.min_magnitude is not None:
+            plt.xlim(args.min_magnitude, plt.xlim()[1])
+        elif args.max_magnitude is not None:
+            plt.xlim(plt.xlim()[0], args.max_magnitude)
         plt.legend(loc='best', fontsize=8)
         plt.savefig(filename,dpi=100)
         sys.stdout.write("Plot saved: {}\n".format(filename))

--- a/doc/vq.tex
+++ b/doc/vq.tex
@@ -706,12 +706,12 @@ failing.
 
 \subsection{Stress Drops \label{sec:stress_drops}}
 
-The stress drops for the fault elements are computed via Wells and Coppersmith 1994 scaling relations along with an analytical solution for the shear stress change per unit slip on a vertical rectangular fault. The simulation is pretty sensitive to these values; large stress drops tend to produce larger earthquakes with longer periods between events, while smaller stress drops produce many more small earthquakes. We provide a tuning parameter that globally adjusts the stress drops, \texttt{sim.friction.stress\_drop\_factor}. The default value is 0.3 and it's logarithmically scaled, and increasing this value by 0.1 multiplies the stress drops by 1.4, a 40\% increase.
+The stress drops for the fault elements are computed via Wells and Coppersmith 1994 scaling relations along with an analytical solution for the shear stress change per unit slip on a vertical rectangular fault. The simulation is pretty sensitive to these values; large stress drops tend to produce larger earthquakes with longer periods between events, while smaller stress drops produce many more small earthquakes. We provide a tuning parameter that globally adjusts the stress drops, and you must specify this when using the mesher to generate your fault model file. The mesher parameter is \texttt{--stress\_drop\_factor=X.X} where X.X is the value of the stress drop factor. The default value is 0.3 and it's logarithmically scaled, and increasing this value by 0.1 multiplies the stress drops by 1.4, a 40\% increase; typical values range from 0.2-0.6.
 
 We begin by using scaling relations to determine a different characteristic magnitude $M^{char}$ and a characteristic slip $\Delta s^{char}$ for each element in a fault based on the fault's geometry from Wells and Coppersmith 1994 scaling relations
 
 \begin{eqnarray}
-	M^{char}  = 4.07 + 0.98 \log_{10} (A) + \mbox{sim.friction.stress\_drop\_factor}
+	M^{char}  = 4.07 + 0.98 \log_{10} (A) + \mbox{stress\_drop\_factor}
 \end{eqnarray}
 
 where $A$ is the surface area of the fault in $km^2$. We then use the definition of moment magnitude to determine the mean slip $\Delta s^{char}$
@@ -2375,10 +2375,6 @@ values indicate ruptures are more likely to propagate along a fault
 and result in larger earthquakes, while lower values indicate ruptures
 are less likely to propagate and result in smaller earthquakes.\tabularnewline
 \hline 
-\texttt{\small{sim.friction.compute\_stress\_drops}} & Boolean. Default is True. If true, compute the stress drops from the fault geometry and scaling relations. If false, must specify stress drops in the model file. See section \ref{sec:stress_drops}.\tabularnewline
-\hline 
-\texttt{\small{sim.friction.stress\_drop\_factor}} & Default is 0.3, this factor is a stress drop multiplier on a log scale. Increasing by 0.1 implies a global stress drop increase of 40\%. Must use this with sim.friction.compute\_stress\_drops. See section \ref{sec:stress_drops}.\tabularnewline
-\hline 
 \end{tabular}
 
 
@@ -2639,6 +2635,7 @@ are grouped by their functionality.
 \hline 
 -d, -\/-delete\_unused & Delete unused vertices after importing files.\tabularnewline
 \hline 
+-q -\/-stress\_drop\_factor & Default is 0.3, this factor is a stress drop multiplier on a log scale. Increasing by 0.1 implies a global stress drop increase of 40\%. See section \ref{sec:stress_drops}.\tabularnewline
 \end{tabular}
 
 

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -830,8 +830,13 @@ void quakelib::ModelWorld::compute_stress_drops(const double &stress_drop_factor
 
 	// Assign a stress drop to each element based on the geometry of the fault it belongs to
     for (eit=_elements.begin(); eit!=_elements.end(); eit++){
+        std::cout << "Grabbing Ele: " << eit->second.id() << " Sec: " << eit->second.section_id();
+        
     	fault_id = section(eit->second.section_id()).fault_id();
         this_fault = fault(fault_id);
+        
+        std::cout << " Fault: " << fault_id;
+        
         fault_area = this_fault.area();
         fault_length = this_fault.length();
         fault_width = fault_area/fault_length;
@@ -847,7 +852,7 @@ void quakelib::ModelWorld::compute_stress_drops(const double &stress_drop_factor
         eit->second.set_stress_drop(stress_drop);
         
         //////////////////////
-        std::cout << stress_drop << std::endl;
+        std::cout << " Drop: " << eit->second.stress_drop() << std::endl;
     }
 
 }

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -870,12 +870,9 @@ void quakelib::ModelWorld::compute_stress_drops(const double &stress_drop_factor
 
 	// Assign a stress drop to each element based on the geometry of the fault it belongs to
     for (eit=_elements.begin(); eit!=_elements.end(); eit++){
-        std::cout << "Grabbing Ele: " << eit->second.id() << " Sec: " << eit->second.section_id();
         
     	fault_id = section(eit->second.section_id()).fault_id();
         this_fault = fault(fault_id);
-        
-        std::cout << " Fault: " << fault_id;
         
         fault_area = this_fault.area();
         fault_length = this_fault.length();

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -492,6 +492,39 @@ namespace quakelib {
             void write_ascii(std::ostream &out_stream) const;
     };
 
+    class fiterator {
+        private:
+            std::map<UIndex, ModelFault>              *_map;
+            std::map<UIndex, ModelFault>::iterator    _it;
+
+        public:
+            fiterator(void) : _map(NULL) {};
+            fiterator(std::map<UIndex, ModelFault> *map, std::map<UIndex, ModelFault>::iterator start) : _map(map), _it(start) {};
+            fiterator &operator=(const fiterator &other) {
+                _map = other._map;
+                _it = other._it;
+                return *this;
+            };
+            bool operator==(const fiterator &other) {
+                return (_map == other._map && _it == other._it);
+            };
+            bool operator!=(const fiterator &other) {
+                return (_map != other._map || _it != other._it);
+            };
+            fiterator &operator++(void) {
+                if (_map && _it != _map->end()) _it++;
+
+                return *this;
+            };
+            ModelFault &operator*(void) {
+                return _it->second;
+            };
+            ModelFault *operator->(void) {
+                return (&*(fiterator)*this);
+            };
+    };
+
+
     class siterator {
         private:
             std::map<UIndex, ModelSection>              *_map;
@@ -1255,6 +1288,13 @@ namespace quakelib {
             };
             siterator end_section(void) {
                 return siterator(&_sections, _sections.end());
+            };
+            
+            fiterator begin_fault(void) {
+                return fiterator(&_faults, _faults.begin());
+            };
+            fiterator end_fault(void) {
+                return fiterator(&_faults, _faults.end());
             };
 
             eiterator begin_element(const UIndex &fid=INVALID_INDEX) {

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -1222,7 +1222,7 @@ namespace quakelib {
             std::map<UIndex, ModelVertex>   _vertices;
             std::map<UIndex, ModelElement>  _elements;
             std::map<UIndex, ModelSection>  _sections;
-            std::map<UIndex, ModelFault>  _faults;
+            std::map<UIndex, ModelFault>    _faults;
             LatLonDepth _base;
             double _min_lat, _max_lat, _min_lon, _max_lon;
 

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -376,70 +376,70 @@ namespace quakelib {
     };
 
     struct FaultData {
-		UIndex              _id;
-		float				_length;
+        UIndex              _id;
+        float               _length;
         float               _area;
-	};
+    };
 
-	class ModelFault : public ModelIO {
-		private:
-			FaultData         _data;
+    class ModelFault : public ModelIO {
+        private:
+            FaultData         _data;
             ElementIDSet      _section_ids;
 
-		public:
-			ModelFault(void) {
-				_data._id = INVALID_INDEX;
-			};
+        public:
+            ModelFault(void) {
+                _data._id = INVALID_INDEX;
+            };
 
-			FaultData data(void) const {
-				return _data;
-			};
+            FaultData data(void) const {
+                return _data;
+            };
 
-			UIndex id(void) const {
-				return _data._id;
-			};
-            
-			void set_id(const UIndex &id) {
-				_data._id = id;
-			};
+            UIndex id(void) const {
+                return _data._id;
+            };
 
-			ElementIDSet section_ids(void) const {
-				return _section_ids;
-			};
-			void insert_section_id(const UIndex &section_id) {
-				_section_ids.insert(section_id);
-			};
-			void set_section_ids(const ElementIDSet &section_ids) {
-				_section_ids = section_ids;
-			};
+            void set_id(const UIndex &id) {
+                _data._id = id;
+            };
 
-			float length(void) const {
-				return _data._length;
-			};
-			void set_length(const float &length) {
-				_data._length = length;
-			};
-            
+            ElementIDSet section_ids(void) const {
+                return _section_ids;
+            };
+            void insert_section_id(const UIndex &section_id) {
+                _section_ids.insert(section_id);
+            };
+            void set_section_ids(const ElementIDSet &section_ids) {
+                _section_ids = section_ids;
+            };
+
+            float length(void) const {
+                return _data._length;
+            };
+            void set_length(const float &length) {
+                _data._length = length;
+            };
+
             float area(void) const {
-				return _data._area;
-			};
-			void set_area(const float &area) {
-				_data._area = area;
-			};
-            
+                return _data._area;
+            };
+            void set_area(const float &area) {
+                _data._area = area;
+            };
+
             static void get_field_descs(std::vector<FieldDesc> &descs);
             void write_ascii(std::ostream &out_stream) const;
             void read_ascii(std::istream &in_stream);
             void read_data(const FaultData &in_data);
             void write_data(FaultData &out_data) const;
-            
+
 #ifdef HDF5_FOUND
             static std::string hdf5_table_name(void) {
                 return "faults";
             };
 #endif
-            
-	};
+
+    };
 
     class FaultTracePoint : public ModelIO {
         private:
@@ -1270,7 +1270,7 @@ namespace quakelib {
             void write_section_hdf5(const int &data_file) const;
             void write_element_hdf5(const int &data_file) const;
             void write_vertex_hdf5(const int &data_file) const;
-            
+
             void write_stress_drop_factor_hdf5(const int &data_file) const;
             void read_stress_drop_factor_hdf5(const int &data_file);
 #endif
@@ -1293,7 +1293,7 @@ namespace quakelib {
             siterator end_section(void) {
                 return siterator(&_sections, _sections.end());
             };
-            
+
             fiterator begin_fault(void) {
                 return fiterator(&_faults, _faults.begin());
             };
@@ -1309,9 +1309,9 @@ namespace quakelib {
             };
 
             UIndex next_fault_index(void) const {
-				if (_faults.size()) return _faults.rbegin()->first+1;
-				else return 0;
-			};
+                if (_faults.size()) return _faults.rbegin()->first+1;
+                else return 0;
+            };
             UIndex next_section_index(void) const {
                 if (_sections.size()) return _sections.rbegin()->first+1;
                 else return 0;
@@ -1336,11 +1336,11 @@ namespace quakelib {
             Vec<3> get_base(void) const {
                 return Vec<3>(_base.lat(), _base.lon(), _base.altitude());
             }
-            
-            double stressDropFactor(void) const{
+
+            double stressDropFactor(void) const {
                 return _stress_drop_factor;
             }
-            
+
             void setStressDropFactor(const double &new_stress_drop_factor) {
                 _stress_drop_factor = new_stress_drop_factor;
             }

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -1258,6 +1258,7 @@ namespace quakelib {
             std::map<UIndex, ModelFault>    _faults;
             LatLonDepth _base;
             double _min_lat, _max_lat, _min_lon, _max_lon;
+            double _stress_drop_factor;
 
 #ifdef HDF5_FOUND
             void read_section_hdf5(const int &data_file);
@@ -1269,6 +1270,9 @@ namespace quakelib {
             void write_section_hdf5(const int &data_file) const;
             void write_element_hdf5(const int &data_file) const;
             void write_vertex_hdf5(const int &data_file) const;
+            
+            void write_stress_drop_factor_hdf5(const int &data_file) const;
+            void read_stress_drop_factor_hdf5(const int &data_file);
 #endif
 
         public:
@@ -1331,6 +1335,14 @@ namespace quakelib {
 
             Vec<3> get_base(void) const {
                 return Vec<3>(_base.lat(), _base.lon(), _base.altitude());
+            }
+            
+            double stressDropFactor(void) const{
+                return _stress_drop_factor;
+            }
+            
+            void setStressDropFactor(const double &new_stress_drop_factor) {
+                _stress_drop_factor = new_stress_drop_factor;
             }
 
             std::vector<double> get_latlon_bounds(void) const {

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -377,13 +377,14 @@ namespace quakelib {
 
     struct FaultData {
 		UIndex              _id;
-		ElementIDSet		_section_ids;
 		float				_length;
+        float               _area;
 	};
 
 	class ModelFault : public ModelIO {
 		private:
 			FaultData         _data;
+            ElementIDSet      _section_ids;
 
 		public:
 			ModelFault(void) {
@@ -397,18 +398,19 @@ namespace quakelib {
 			UIndex id(void) const {
 				return _data._id;
 			};
+            
 			void set_id(const UIndex &id) {
 				_data._id = id;
 			};
 
 			ElementIDSet section_ids(void) const {
-				return _data._section_ids;
+				return _section_ids;
 			};
 			void insert_section_id(const UIndex &section_id) {
-				_data._section_ids.insert(section_id);
+				_section_ids.insert(section_id);
 			};
 			void set_section_ids(const ElementIDSet &section_ids) {
-				_data._section_ids = section_ids;
+				_section_ids = section_ids;
 			};
 
 			float length(void) const {
@@ -417,6 +419,26 @@ namespace quakelib {
 			void set_length(const float &length) {
 				_data._length = length;
 			};
+            
+            float area(void) const {
+				return _data._area;
+			};
+			void set_area(const float &area) {
+				_data._area = area;
+			};
+            
+            static void get_field_descs(std::vector<FieldDesc> &descs);
+            void write_ascii(std::ostream &out_stream) const;
+            void read_ascii(std::istream &in_stream);
+            void read_data(const FaultData &in_data);
+            void write_data(FaultData &out_data) const;
+            
+#ifdef HDF5_FOUND
+            static std::string hdf5_table_name(void) {
+                return "faults";
+            };
+#endif
+            
 	};
 
     class FaultTracePoint : public ModelIO {
@@ -1316,6 +1338,7 @@ namespace quakelib {
                                 const bool resize_trace_elements);
 
             void create_faults(void);
+            void compute_stress_drops(const double &stress_drop_factor);
 
             int read_file_ascii(const std::string &file_name);
             int write_file_ascii(const std::string &file_name) const;
@@ -1335,6 +1358,7 @@ namespace quakelib {
             double linear_interp(const double &x, const double &x_min, const double &x_max, const double &y_min, const double &y_max) const;
             char *rgb2hex(const int r, const int g, const int b) const;
             double section_length(const UIndex &sec_id) const;
+            double section_area(const quakelib::UIndex &sec_id) const;
             double section_max_depth(const UIndex &sec_id) const;
     };
 

--- a/quakelib/src/QuakeLibUtil.cpp
+++ b/quakelib/src/QuakeLibUtil.cpp
@@ -187,12 +187,12 @@ quakelib::Vec<3> quakelib::Conversion::convert2xyz(const LatLonDepth &in_pt) con
 #endif
 
 quakelib::Vec<3> quakelib::Conversion::yxz2xyz(const LatLonDepth &in_pt) const {
-	//Use for importing trace in (y, x) halfspace coords.  Must turn off LatLonDepth error throwning for angles out of bounds in QuakeLibUtil.h.
+    //Use for importing trace in (y, x) halfspace coords.  Must turn off LatLonDepth error throwning for angles out of bounds in QuakeLibUtil.h.
     double  new_vals[3];
 
     new_vals[0] = in_pt.lon();
-	new_vals[1] = in_pt.lat();
-	new_vals[2] = in_pt.altitude();
+    new_vals[1] = in_pt.lat();
+    new_vals[2] = in_pt.altitude();
 
     return Vec<3>(new_vals);
 }

--- a/quakelib/src/QuakeLibUtil.h
+++ b/quakelib/src/QuakeLibUtil.h
@@ -469,7 +469,7 @@ namespace quakelib {
             Vec<3> convert2xyz(const LatLonDepth &in_pt) const;
 
             //! Used for reading in km-space trace files.
-			Vec<3> yxz2xyz(const LatLonDepth &in_pt) const;
+            Vec<3> yxz2xyz(const LatLonDepth &in_pt) const;
 
             //! Convert the specified Cartesian coordinate to latitude/longitude using the base as (0,0,0).
             LatLonDepth convert2LatLon(const Vec<3> &in_pt) const;

--- a/src/core/Params.cpp
+++ b/src/core/Params.cpp
@@ -117,14 +117,8 @@ void VCParams::read_params(const std::string &param_file_name) {
     //printf("greens limits: %f, %f, %f, %f, %f, %f, %f, %f", params.read<double>("sim.greens.shear_diag_max"), params.read<double>("sim.greens.shear_diag_min"), params.read<double>("sim.greens.shear_offdiag_max"), params.read<double>("sim.greens.shear_offdiag_min"), params.read<double>("sim.greens.normal_diag_max"), params.read<double>("sim.greens.normal_diag_min"), params.read<double>("sim.greens.normal_offdiag_max"), params.read<double>("sim.greens.normal_offdiag_min"));
     //
 
-    // Kasey: parameter to either read in stress drops from file or compute them
-    params.readSet<bool>("sim.friction.compute_stress_drops", true);
-
-    params.readSet<double>("sim.friction.stress_drop_factor", 0.4);
 
     params.readSet<bool>("sim.friction.dynamic_stress_drops", false);
-
-    //params.readSet<double>("sim.friction.coefficient", 0.6);
 
     //params.readSet<bool>("sim.system.cellular_automata_model", 0);
 

--- a/src/core/Params.h
+++ b/src/core/Params.h
@@ -250,9 +250,9 @@ class VCParams {
 
         // Schultz: Cellular automata model means we don't use interactions in secondary rupture model
         //   matrix solutions for slip. AKA: True = Michael's VC type, False: Eric's VQ type
-//        bool doCellularAutomata(void) const {
-//            return params.read<bool>("sim.system.cellular_automata_model");
-//        };
+        //        bool doCellularAutomata(void) const {
+        //            return params.read<bool>("sim.system.cellular_automata_model");
+        //        };
 
 
 };

--- a/src/core/Params.h
+++ b/src/core/Params.h
@@ -202,27 +202,16 @@ class VCParams {
             return params.read<double>("sim.greens.normal_offdiag_min");
         };
 
-        bool computeStressDrops(void) const {
-            return params.read<bool>("sim.friction.compute_stress_drops");
-        };
-
         // Kasey: new parameter. Compute dynamic stress drops (True) or
         // computing from standard method (False)
         bool doDynamicStressDrops(void) const {
             return params.read<bool>("sim.friction.dynamic_stress_drops");
         };
 
-        // Schultz: Prescribe a constant coefficient of friction for all blocks
-//        double getFrictionCoefficient(void) const {
-//            return params.read<double>("sim.friction.coefficient");
-//        };
-
         // The constant adjustment to the stress drops, should be between 0.3 and 0.5 globally
         //     with tuning the larger faults may need 0.6 to 0.8. The larger the number, the larger
         //     the stress drops. Currently it's a global constant
-        double stressDropFactor(void) const {
-            return params.read<double>("sim.friction.stress_drop_factor");
-        };
+        // MOVED TO MESHER
 
         //
         // yoder: and overload so we can easily distinguish (off)diagonal elements (defined in GreensInit.cpp)

--- a/src/core/SimData.h
+++ b/src/core/SimData.h
@@ -57,6 +57,7 @@ class VCSimData : public VCSimDataBlocks, public VCSimDataEvents {
         double                  *normal_stress0;
         double                  *dynamic_val;
         bool                    *failed;
+        double                  stress_drop_factor;
         std::map<BlockID, double>   init_shear_stress;
         std::map<BlockID, double>   init_normal_stress;
         std::map<SectionID, double>   fault_lengths;
@@ -67,7 +68,7 @@ class VCSimData : public VCSimDataBlocks, public VCSimDataEvents {
             shear_stress(NULL), normal_stress(NULL), update_field(NULL), slip_deficit(NULL),
             rhogd(NULL), stress_drop(NULL), max_stress_drop(NULL), cff(NULL), friction(NULL), cff0(NULL),
             self_shear(NULL), self_normal(NULL), shear_stress0(NULL), normal_stress0(NULL),
-            dynamic_val(NULL), failed(NULL) {};
+            dynamic_val(NULL), failed(NULL), stress_drop_factor(0) {};
 
         void setupArrays(const unsigned int &global_sys_size,
                          const unsigned int &local_sys_size,

--- a/src/core/SimData.h
+++ b/src/core/SimData.h
@@ -59,8 +59,8 @@ class VCSimData : public VCSimDataBlocks, public VCSimDataEvents {
         bool                    *failed;
         std::map<BlockID, double>   init_shear_stress;
         std::map<BlockID, double>   init_normal_stress;
-        std::map<SectionID, double>   section_lengths;
-        std::map<SectionID, double>   section_areas;
+        std::map<SectionID, double>   fault_lengths;
+        std::map<SectionID, double>   fault_areas;
 
     public:
         VCSimData(void) : global_size(0), local_size(0), green_shear(NULL), green_normal(NULL),

--- a/src/core/Simulation.cpp
+++ b/src/core/Simulation.cpp
@@ -50,8 +50,8 @@ Simulation::Simulation(int argc, char **argv) : SimFramework(argc, argv) {
 
     // Check validity of parameters
     // TODO: add more checks here
-    assertThrow(!getVersion().compare("2.0"),
-                "sim.version: Parameter file version must be 2.0");
+    //assertThrow(!getVersion().compare("2.0"),
+    //            "sim.version: Parameter file version must be 2.0");
     assertThrow(getSimStart()>=0,
                 "sim.start_year: Start year must be at least 0.");
     assertThrow(getSimStart() < getSimDuration(),

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -253,7 +253,8 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
         };
 
         //! Set the stress drop for this block in Pascals.
-        void setStressDrop(const BlockID gid, const double new_stress_drop) {
+        void setStressDrop(const BlockID gid, double new_stress_drop) {
+            if (new_stress_drop > 0) new_stress_drop = -new_stress_drop;
             stress_drop[gid] = new_stress_drop;
             calcFriction(gid);
         };

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -251,6 +251,15 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
             stress_drop[gid] = new_stress_drop;
             calcFriction(gid);
         };
+        
+        //! Set the stress drop factor for the simulation.
+        double stressDropFactor(void) const {
+            return stress_drop_factor;
+        };
+        void setStressDropFactor(double new_factor) {
+            stress_drop_factor = new_factor;
+        };
+        
 
         //! Get the max stress drop for this block in Pascals.
         double getMaxStressDrop(const BlockID gid) const {

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -201,15 +201,28 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
         };
 
         //! Get the area for the section in square meters.
-        double getSectionArea(const SectionID sid) const {
-            return section_areas.find(sid)->second;
+        double getFaultArea(const SectionID fid) const {
+            return fault_areas.find(fid)->second;
         };
         //! Set the area for the section in square meters.
-        void setSectionArea(const SectionID sid, const double new_area) {
-            if (section_areas.count(sid)) {
-                section_areas.find(sid)->second = new_area;
+        void setFaultArea(const SectionID fid, const double new_area) {
+            if (fault_areas.count(fid)) {
+                fault_areas.find(fid)->second = new_area;
             } else {
-                section_areas.insert(std::make_pair(sid, new_area));
+                fault_areas.insert(std::make_pair(fid, new_area));
+            }
+        };
+        
+        //! Get the area for the section in square meters.
+        double getFaultLength(const SectionID fid) const {
+            return fault_lengths.find(fid)->second;
+        };
+        //! Set the area for the section in square meters.
+        void setFaultLength(const SectionID fid, const double new_length) {
+            if (fault_lengths.count(fid)) {
+                fault_lengths.find(fid)->second = new_length;
+            } else {
+                fault_lengths.insert(std::make_pair(fid, new_length));
             }
         };
 
@@ -219,8 +232,8 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
             double char_magnitude, R, nu, dynamicStressDrop;
 
             // Fault wise data
-            fault_area = getSectionArea(getBlock(gid).getSectionID());
-            fault_length = getSectionLength(getBlock(gid).getSectionID());
+            fault_area = getFaultArea(getBlock(gid).getFaultID());
+            fault_length = getFaultLength(getBlock(gid).getFaultID());
             fault_width = fault_area/fault_length;
             R = sqrt(fault_length*fault_length + fault_width*fault_width);
             nu = 0.5*getBlock(gid).lame_lambda()/(getBlock(gid).lame_mu() + getBlock(gid).lame_lambda());
@@ -232,19 +245,6 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
             dynamicStressDrop = -2*getBlock(gid).lame_mu()*char_slip*( (1-nu)*fault_length/fault_width + fault_width/fault_length )/( (1-nu)*M_PI*R );
 
             return dynamicStressDrop;
-        };
-
-        //! Get the length for the section in meters.
-        double getSectionLength(const SectionID sid) const {
-            return section_lengths.find(sid)->second;
-        };
-        //! Set the length for the section in meters.
-        void setSectionLength(const SectionID sid, const double new_length) {
-            if (section_lengths.count(sid)) {
-                section_lengths.find(sid)->second = new_length;
-            } else {
-                section_lengths.insert(std::make_pair(sid, new_length));
-            }
         };
 
         //! Get the stress drop for this block in Pascals.

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -159,13 +159,6 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
             return friction[gid];
         }
 
-//        void setFriction(const BlockID gid, const double coefficient) {
-//            // Schultz: Cannot let friction decrease with increasing depth.
-//            // Instead lets prescribe a coefficient.
-//            // TODO: Add friction file reading so we can specify coeff. per block
-//            friction[gid] = coefficient;
-//        }
-
         //! Whether the block experienced static friction failure.
         //! This occurs if the Coulomb failure function goes over 0.
         bool cffFailure(const BlockID gid) const {

--- a/src/core/Simulation.h
+++ b/src/core/Simulation.h
@@ -205,7 +205,7 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
                 fault_areas.insert(std::make_pair(fid, new_area));
             }
         };
-        
+
         //! Get the area for the section in square meters.
         double getFaultLength(const SectionID fid) const {
             return fault_lengths.find(fid)->second;
@@ -248,10 +248,11 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
         //! Set the stress drop for this block in Pascals.
         void setStressDrop(const BlockID gid, double new_stress_drop) {
             if (new_stress_drop > 0) new_stress_drop = -new_stress_drop;
+
             stress_drop[gid] = new_stress_drop;
             calcFriction(gid);
         };
-        
+
         //! Set the stress drop factor for the simulation.
         double stressDropFactor(void) const {
             return stress_drop_factor;
@@ -259,7 +260,7 @@ class Simulation : public SimFramework, public VCParams, public VCSimData, publi
         void setStressDropFactor(double new_factor) {
             stress_drop_factor = new_factor;
         };
-        
+
 
         //! Get the max stress drop for this block in Pascals.
         double getMaxStressDrop(const BlockID gid) const {

--- a/src/io/ReadModelFile.cpp
+++ b/src/io/ReadModelFile.cpp
@@ -71,7 +71,10 @@ void ReadModelFile::init(SimFramework *_sim) {
         sim->setFaultLength(fit->id(), fit->length());
     }
 
-
+    // Tell the simulation what the stress drop factor is (used for dynamic stress drops)
+    sim->setStressDropFactor(world.stressDropFactor());
+    std::cout << "# Sim stress drop factor set: " << sim->stressDropFactor() << std::endl;
+    
     // Convert input world to simulation elements
     for (eit=world.begin_element(); eit!=world.end_element(); ++eit) {
         Block                   new_block;

--- a/src/io/ReadModelFile.cpp
+++ b/src/io/ReadModelFile.cpp
@@ -41,6 +41,7 @@ void ReadModelFile::init(SimFramework *_sim) {
     std::string                 file_name, file_type, stress_filename, stress_file_type, stress_index_filename;
     quakelib::ModelWorld        world;
     quakelib::siterator         sit;
+    quakelib::fiterator         fit;
     quakelib::eiterator         eit;
     int                         err;
     quakelib::Conversion        c;
@@ -63,6 +64,13 @@ void ReadModelFile::init(SimFramework *_sim) {
         sim->errConsole() << "ERROR: could not read file " << file_name << std::endl;
         return;
     }
+
+    // Load in fault length and area data
+    for (fit=world.begin_fault(); fit!=world.end_fault(); ++fit) {
+        sim->setFaultArea(fit->id(), fit->area());
+        sim->setFaultLength(fit->id(), fit->length());
+    }
+
 
     // Convert input world to simulation elements
     for (eit=world.begin_element(); eit!=world.end_element(); ++eit) {

--- a/src/io/ReadModelFile.cpp
+++ b/src/io/ReadModelFile.cpp
@@ -74,7 +74,7 @@ void ReadModelFile::init(SimFramework *_sim) {
     // Tell the simulation what the stress drop factor is (used for dynamic stress drops)
     sim->setStressDropFactor(world.stressDropFactor());
     std::cout << "# Sim stress drop factor set: " << sim->stressDropFactor() << std::endl;
-    
+
     // Convert input world to simulation elements
     for (eit=world.begin_element(); eit!=world.end_element(); ++eit) {
         Block                   new_block;

--- a/src/mesher.cpp
+++ b/src/mesher.cpp
@@ -42,11 +42,12 @@ static struct option longopts[] = {
     { "delete_unused",              no_argument,            NULL,           'd' },
     { "taper_fault_method",         required_argument,      NULL,           't' },
     { "print_statistics",           required_argument,      NULL,           's' },
+    { "do_not_compute_stress_drops",no_argument,            NULL,           'x' },
+    { "stress_drop_factor",         required_argument,      NULL,           'q' },
+
     { NULL,                         0,                      NULL,           0 }
 };
 
-//    { "do_not_compute_stress_drops",no_argument,            NULL,           'x' },
-//    { "stress_drop_factor",         required_argument,      NULL,           'q' },
 
 std::string mem_string(const double &num_bytes) {
     std::stringstream       ss;
@@ -213,7 +214,7 @@ int main (int argc, char **argv) {
     eqsim_geom_in_file = eqsim_fric_in_file = eqsim_cond_in_file = "";
     eqsim_geom_out_file = eqsim_fric_out_file = eqsim_cond_out_file = "";
 
-    while ((ch = getopt_long(argc, argv, "mdrs:D:R:M:C:F:G:i:j:e:f:l:t:", longopts, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "mdr:x:s:q:D:R:M:C:F:G:i:j:e:f:l:t:", longopts, NULL)) != -1) {
         switch (ch) {
             case 'd':
                 delete_unused = true;
@@ -227,17 +228,18 @@ int main (int argc, char **argv) {
                 resize_trace_elements = true;
                 break;
                 
-//            case 'x':
-//                compute_stress_drops = false;
-//                break;
+            case 'x':
+                compute_stress_drops = false;
+                std::cout << " === NOT computing stress drops ==="  << std::endl;
+                break;
 
             case 's':
                 stat_out_file = optarg;
                 break;
 
-//            case 'q':
-//                stress_drop_factor = atof(optarg);
-//                break;
+            case 'q':
+                stress_drop_factor = atof(optarg);
+                break;
 
             case 'D':
                 eqsim_cond_out_file = optarg;

--- a/src/mesher.cpp
+++ b/src/mesher.cpp
@@ -437,6 +437,7 @@ int main (int argc, char **argv) {
     if (compute_stress_drops) {
         std::cout << "Computing stress drops with stress_drop_factor=" << stress_drop_factor << std::endl;
         world.compute_stress_drops(stress_drop_factor);
+        world.setStressDropFactor(stress_drop_factor);
     }
 
 

--- a/src/mesher.cpp
+++ b/src/mesher.cpp
@@ -227,7 +227,7 @@ int main (int argc, char **argv) {
             case 'r':
                 resize_trace_elements = true;
                 break;
-                
+
             case 'x':
                 compute_stress_drops = false;
                 std::cout << " === NOT computing stress drops ==="  << std::endl;

--- a/src/mesher.cpp
+++ b/src/mesher.cpp
@@ -45,6 +45,9 @@ static struct option longopts[] = {
     { NULL,                         0,                      NULL,           0 }
 };
 
+//    { "do_not_compute_stress_drops",no_argument,            NULL,           'x' },
+//    { "stress_drop_factor",         required_argument,      NULL,           'q' },
+
 std::string mem_string(const double &num_bytes) {
     std::stringstream       ss;
     int unit_place = (num_bytes > 0 ? (int)(log(num_bytes)/log(1024)) : 0);
@@ -155,6 +158,10 @@ void print_usage(int argc, char **argv) {
     std::cerr << "-r, --resize_trace_elements" << std::endl;
     std::cerr << "\tResize elements generated on traces to better match fault length." << std::endl;
     std::cerr << "\tThis will only decrease and at most halve the element size." << std::endl;
+    std::cerr << "-x, --do_not_compute_stress_drops" << std::endl;
+    std::cerr << "\tDo not compute stress drops, must specify from EQSim friction instead." << std::endl;
+    std::cerr << "-q FACTOR, --stress_drop_factor=FACTOR" << std::endl;
+    std::cerr << "\tSpecify the stress drop factor (usually 0.2-0.6). It's a multiplier for the computed stress drops (it's logarithmic, 0.1 increase means multiplying stress drops by 1.4)." << std::endl;
 
     std::cerr << std::endl;
     std::cerr << "FILE IMPORT" << std::endl;
@@ -189,7 +196,7 @@ void print_usage(int argc, char **argv) {
 
 int main (int argc, char **argv) {
     quakelib::ModelWorld        world;
-    bool                        delete_unused, merge_duplicate_vertices, resize_trace_elements;
+    bool                        delete_unused, merge_duplicate_vertices, resize_trace_elements, compute_stress_drops=true;
     bool                        arg_error, failed;
     std::string                 names[2] = {"import", "export"};
     std::string                 eqsim_geom_in_file, eqsim_fric_in_file, eqsim_cond_in_file;
@@ -198,6 +205,7 @@ int main (int argc, char **argv) {
     std::vector<std::string>    files[2], types[2];
     std::vector<std::string>    taper_fault_methods;
     std::vector<double>         trace_element_sizes;
+    double                      stress_drop_factor = 0.3;  // default value is a reasonable 0.3
     int                         ch, res;
     unsigned int                i, n, j, num_trace_files;
 
@@ -218,10 +226,18 @@ int main (int argc, char **argv) {
             case 'r':
                 resize_trace_elements = true;
                 break;
+                
+//            case 'x':
+//                compute_stress_drops = false;
+//                break;
 
             case 's':
                 stat_out_file = optarg;
                 break;
+
+//            case 'q':
+//                stress_drop_factor = atof(optarg);
+//                break;
 
             case 'D':
                 eqsim_cond_out_file = optarg;
@@ -319,6 +335,12 @@ int main (int argc, char **argv) {
         }
     }
 
+    if (!(compute_stress_drops) && (eqsim_fric_in_file.empty() || eqsim_geom_in_file.empty() )) {
+        std::cerr << "ERROR: If not computing stress drops, must specify EQSim geometry and EQSim friction file. EQSim friction should contain stress drops." << std::endl;
+        arg_error = true;
+    }
+
+
     // If any argument was malformed, print the correct usage
     if (arg_error) {
         print_usage(argc, argv);
@@ -404,6 +426,17 @@ int main (int argc, char **argv) {
     // Here we take the final fault model and create ModelFault objects, which correctly rewrites DAS for
     // each vertex to be relative to fault, applies horizontal tapering wrt length of fault
     world.create_faults();
+
+
+    // Schultz: Moving stress drop computation here (used to be in UpdateBlockStress.cpp.
+    // ------------------------------------------------------------------------------------------
+    // Compute the stress drops. Default behavior is to compute them. To prescribe stress drops,
+    //   one must specify the values in an EQSim friction file.
+    if (compute_stress_drops) {
+        std::cout << "Computing stress drops with stress_drop_factor=" << stress_drop_factor << std::endl;
+        world.compute_stress_drops(stress_drop_factor);
+    }
+
 
     // *** OUTPUT SECTION ***
     // Finally, export the appropriate file types

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -224,12 +224,12 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
     // stress transfer (greens functions) between each local element and all global elements.
     for (i=0,it=local_secondary_id_list.begin(); it!=local_secondary_id_list.end(); ++i,++it) {
         for (n=0,jt=global_secondary_id_list.begin(); jt!=global_secondary_id_list.end(); ++n,++jt) {
-            
+
             A[i*num_global_failed+n] = sim->getGreenShear(*it, jt->first);
 
             if (sim->doNormalStress()) {
                 A[i*num_global_failed+n] -= sim->getFriction(*it)*sim->getGreenNormal(*it, jt->first);
-            }            
+            }
         }
 
         ///// Schultz:
@@ -512,13 +512,13 @@ void RunEvent::processStaticFailure(Simulation *sim) {
         sim->distributeBlocks(local_failed_elements, global_failed_elements);
         //sim->barrier(); // yoder: (debug)
         //
-        
-        
+
+
         ///////////////////////////////////////////////////////////////////
         // TEMPORARY OUTPUT, only works on 1 proc
-//        for (unsigned int gid=0; gid<sim->numGlobalBlocks(); ++gid) {
-//            sim->console() << sweep_num << "  " << gid << "  " << sim->getShearStress(gid) << "  " << sim->getNormalStress(gid) << "  " << sim->getCFF(gid) << "  " << sim->getStressDrop(gid) << std::endl;
-//        }
+        //        for (unsigned int gid=0; gid<sim->numGlobalBlocks(); ++gid) {
+        //            sim->console() << sweep_num << "  " << gid << "  " << sim->getShearStress(gid) << "  " << sim->getNormalStress(gid) << "  " << sim->getCFF(gid) << "  " << sim->getStressDrop(gid) << std::endl;
+        //        }
         ///////////////////////////////////////////////////////////////////
 
 
@@ -924,6 +924,7 @@ SimRequest RunEvent::run(SimFramework *_sim) {
 #else
     //global_event_size=local_event_size;
     int global_event_size = sim->getCurrentEvent().size();
+
     assertThrow(global_event_size > 0, "There was a trigger but no failed blocks. (" << getpid() << "/" << sim->getNodeRank() << ")");
 
 #endif

--- a/src/simulation/RunEvent.cpp
+++ b/src/simulation/RunEvent.cpp
@@ -200,7 +200,7 @@ void RunEvent::processBlocksSecondaryFailures(Simulation *sim, quakelib::ModelSw
         }
 
         for (cit=current_blocks.begin(); cit!=current_blocks.end(); ++cit) {
-            if (current_event_area < sim->getSectionArea(sim->getBlock(*cit).getSectionID())) {
+            if (current_event_area < sim->getFaultArea(sim->getBlock(*cit).getFaultID())) {
                 // If the current area is smaller than the section area, scale the stress drop
                 dynamicStressDrop = sim->computeDynamicStressDrop(*cit, current_event_area);
                 sim->setStressDrop(*cit, dynamicStressDrop);
@@ -541,7 +541,7 @@ void RunEvent::processStaticFailure(Simulation *sim) {
             }
 
             for (cit=current_blocks.begin(); cit!=current_blocks.end(); ++cit) {
-                if (current_event_area < sim->getSectionArea(sim->getBlock(*cit).getSectionID())) {
+                if (current_event_area < sim->getFaultArea(sim->getBlock(*cit).getFaultID())) {
                     // If the current area is smaller than the section area, scale the stress drop
                     dynamicStressDrop = sim->computeDynamicStressDrop(*cit, current_event_area);
                     sim->setStressDrop(*cit, dynamicStressDrop);

--- a/src/simulation/UpdateBlockStress.cpp
+++ b/src/simulation/UpdateBlockStress.cpp
@@ -102,11 +102,11 @@ void UpdateBlockStress::init(SimFramework *_sim) {
         //std::cout << gid << "  slip deficit: " << sim->getSlipDeficit(gid) << std::endl;
     }
 
-    // Schultz: Now, stress drop computation has moved to the mesher. Here we just read in the 
+    // Schultz: Now, stress drop computation has moved to the mesher. Here we just read in the
     //          pre-computed stress drops from the fault model.
     for (lid=0; lid<sim->numLocalBlocks(); ++lid) {
         gid = sim->getGlobalBID(lid);
-        
+
         depth = fabs(sim->getBlock(gid).center()[2]);  // depth of block center in m
 
         sim->setRhogd(gid, rho*g*depth);       // kg m^-3 * m s^-2 * m = kg m^-1 * s^-2 = Pa


### PR DESCRIPTION
Stress drops are now computed as a mesher function. Added the following mesher options
--stress_drop_factor=X.X
--do_not_compute_stress_drops (if specifying drops in an EQSim friction file)

ModelFault data is used for stress drop functions, meaning that stress drops for multi-section faults are now different (they were previously computed with section-specific geometry info).