### PR TITLE
EQSim file-writing fix, new --save_greens option

### DIFF
--- a/PyVQ/pyvq/pyvq.py
+++ b/PyVQ/pyvq/pyvq.py
@@ -893,6 +893,18 @@ class GreensPlotter:
                     loc       = quakelib.Vec3(self.XX[i][j], self.YY[i][j], 0.0)
                     self.field[i][j] = self.block.calc_displacement_vector(loc, self.C, self.dip, self.L, self.W, self.US, self.UD, self.UT, self._lambda, self._mu)[2]
     
+    def save_greens(self, output_file):
+        output_file = output_file.split('.png')[0]+'.txt'
+        outfile = open(output_file,'w')
+        # self.field[i][j] is the field value matrix
+        # self.XX[i][j] is the x coordinate
+        # self.YY[i][j] is the y coordinate
+        sys.stdout.write("Writing greens function values to {} in the format of\nX[m]\tY[m]\tfield value\n".format(output_file))
+        for i in range(self.XX.shape[0]):
+            for j in range(self.XX.shape[1]):
+                outfile.write("{:.6f}\t{:.6f}\t{:.6f}\n".format(self.XX[i][j],self.YY[i][j],self.field[i][j]))
+        
+    
     def plot_field(self, output_file, no_labels=False, cbar_loc='top', tick_font=18, frame_font=18, x_ticks=True):
         ticklabelfont = mfont.FontProperties(family='Arial', style='normal', variant='normal', size=tick_font)
         framelabelfont = mfont.FontProperties(family='Arial', style='normal', variant='normal', size=frame_font)
@@ -2696,7 +2708,8 @@ if __name__ == "__main__":
     parser.add_argument('--lld_file', required=False, help="File containing lat/lon columns to evaluate an event field.")
     
     # Greens function plotting arguments
-    parser.add_argument('--greens', required=False, action='store_true', help="Plot single element Okubo Green's functions. Field type also required.")            
+    parser.add_argument('--greens', required=False, action='store_true', help="Plot single element Okubo Green's functions. Field type also required.") 
+    parser.add_argument('--save_greens', required=False, action='store_true', help="Save single element Okubo Green's function values.")            
     parser.add_argument('--plot_name', required=False, help="Name for saving the plot to file.")
     parser.add_argument('--Nx', required=False, type=int, help="Number of points along x axis to evaluate function (default 690).")
     parser.add_argument('--Ny', required=False, type=int, help="Number of points along y axis to evaluate function. (default 422)")
@@ -3100,6 +3113,8 @@ if __name__ == "__main__":
         GP = GreensPlotter(args.field_type, cbar_max=args.colorbar_max, levels=args.levels, Nx=args.Nx, Ny=args.Ny, Xmin=args.Xmin, Xmax=args.Xmax, Ymin=args.Ymin, Ymax=args.Ymax, L=args.L, W=args.W, DTTF=args.DTTF, slip=args.uniform_slip, dip=args.dip, _lambda=args._lambda, _mu=args.mu, rake=args.rake, g0=args.g)
         GP.compute_field()
         GP.plot_field(filename)
+        if args.save_greens:
+            GP.save_greens(filename)
     if args.traces:
         filename = SaveFile().trace_plot(args.model_file)
         if args.small_model is None: args.small_model = False

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -2823,10 +2823,10 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
             out_file << "\t\t\t\t\t<LinearRing>\n";
             out_file << "\t\t\t\t\t\t<coordinates>\n";
             //TODO: Fix compatibility with triangular models when we have them
-            //npoints = (eit->second.is_quad() ? 4 : 3);
-            npoints = 4;
+            npoints = (_elements.find(*it)->second.is_quad() ? 4 : 3);
+            //npoints = 4;
 
-            for (i=0; i<npoints; ++i) out_file << "\t\t\t\t\t\t\t" << lld[i%npoints].lon() << "," << lld[i%npoints].lat() << "," << max_depth + lld[i%npoints].altitude() << "\n";
+            for (i=0; i<npoints; ++i) out_file << "\t\t\t\t\t\t\t" << lld[i].lon() << "," << lld[i].lat() << "," << max_depth + lld[i].altitude() << "\n";
 
             out_file << "\t\t\t\t\t\t</coordinates>\n";
             out_file << "\t\t\t\t\t</LinearRing>\n";
@@ -2857,10 +2857,10 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
             out_file << "\t\t\t\t\t<LinearRing>\n";
             out_file << "\t\t\t\t\t\t<coordinates>\n";
             //TODO: Fix compatibility with triangular models when we have them
-            //npoints = (eit->second.is_quad() ? 4 : 3);
-            npoints = 4;
+            npoints = (_elements.find(*it)->second.is_quad() ? 4 : 3);
+            //npoints = 4;
 
-            for (i=0; i<npoints; ++i) out_file << "\t\t\t\t\t\t\t" << lld[i%npoints].lon() << "," << lld[i%npoints].lat() << "," << max_depth + lld[i%npoints].altitude() << "\n";
+            for (i=0; i<npoints; ++i) out_file << "\t\t\t\t\t\t\t" << lld[i].lon() << "," << lld[i].lat() << "," << max_depth + lld[i].altitude() << "\n";
 
             out_file << "\t\t\t\t\t\t</coordinates>\n";
             out_file << "\t\t\t\t\t</LinearRing>\n";

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -2420,12 +2420,15 @@ int quakelib::ModelWorld::write_files_eqsim(const std::string &geom_file_name, c
             v1.set_loc(vertex(eit->vertex(1)).lld());
             v1.set_das(vertex(eit->vertex(1)).das());
             v1.set_trace_flag(NOT_ON_TRACE);
-            v2.set_loc(vertex(eit->vertex(2)).lld());
-            v2.set_das(vertex(eit->vertex(2)).das());
-            v2.set_trace_flag(NOT_ON_TRACE);
-            // Fourth vertex is implicit so we calculate it
-            v3.set_loc(c.convert2LatLon(sim_elem.implicit_vert()));
+            //v2.set_loc(vertex(eit->vertex(2)).lld());
+            //v2.set_das(vertex(eit->vertex(2)).das());
+            v3.set_loc(vertex(eit->vertex(2)).lld());
             v3.set_das(vertex(eit->vertex(2)).das());
+            v2.set_trace_flag(NOT_ON_TRACE);
+            //v3.set_loc(c.convert2LatLon(sim_elem.implicit_vert()));
+            //v3.set_das(vertex(eit->vertex(2)).das());
+            v2.set_loc(c.convert2LatLon(sim_elem.implicit_vert()));
+            v2.set_das(vertex(eit->vertex(2)).das());
             v3.set_trace_flag(NOT_ON_TRACE);
         }
     }
@@ -2586,6 +2589,7 @@ int quakelib::ModelWorld::write_file_kml(const std::string &file_name) {
                 out_file << "\t\t<description>\n";
                 out_file << "Fault name: " << fit->second.name() << "\n";
                 out_file << "Element #: " << eit->second.id() << "\n";
+                out_file << "DAS [km]: " << element_min_das(eit->first)/1000.0 << " to " << element_max_das(eit->first)/1000.0 << "\n";
                 out_file << "Slip rate: " << c.m_per_sec2cm_per_yr(eit->second.slip_rate()) << " cm/year\n";
                 out_file << "Rake: " << c.rad2deg(eit->second.rake()) << " degrees\n";
                 out_file << "Aseismic: " << eit->second.aseismic() << "\n";
@@ -2805,7 +2809,7 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
             out_file << "\t\t<description>\n";
             out_file << "Element #: " << *it << "\n";
             out_file << "Event slip [m]: " << event.getEventSlip(*it) << "\n";
-            out_file << "Distance along strike [km]: " << element_min_das(*it)/1000.0 << " to " << element_max_das(*it)/1000.0 << "\n";
+            out_file << "DAS [km]: " << element_min_das(*it)/1000.0 << " to " << element_max_das(*it)/1000.0 << "\n";
             out_file << "\t\t</description>\n";
             out_file << "\t\t\t<Style>\n";
             out_file << "\t\t\t\t<LineStyle>\n";
@@ -2826,7 +2830,7 @@ int quakelib::ModelWorld::write_event_kml(const std::string &file_name, const qu
             npoints = (_elements.find(*it)->second.is_quad() ? 4 : 3);
             //npoints = 4;
 
-            for (i=0; i<npoints; ++i) out_file << "\t\t\t\t\t\t\t" << lld[i].lon() << "," << lld[i].lat() << "," << max_depth + lld[i].altitude() << "\n";
+            for (i=0; i<npoints+1; ++i) out_file << "\t\t\t\t\t\t\t" << lld[i%npoints].lon() << "," << lld[i%npoints].lat() << "," << max_depth + lld[i%npoints].altitude() << "\n";
 
             out_file << "\t\t\t\t\t\t</coordinates>\n";
             out_file << "\t\t\t\t\t</LinearRing>\n";


### PR DESCRIPTION
For single fault Okubo-style field plots, now you can save the field values to a text file using "--save_greens"

Fixed a bug in the vertex numbering for EQSim file writing