### PR TITLE
Added mesher export file type trace_faultwise

### DIFF
--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -1187,8 +1187,7 @@ void quakelib::ModelWorld::reset_base_coord(const LatLonDepth &new_base) {
     _base = new_base;
 }
 
-// TODO: Currently only supports sections where top element is at the same depth, change to support more complex faults
-// Also assumes elements will be in order along the trace
+// Assumes elements will be in order along the trace
 // TODO: add element comments to output
 int quakelib::ModelWorld::write_file_trace_latlon(void) {
     eiterator           eit, last_element;
@@ -1304,6 +1303,144 @@ int quakelib::ModelWorld::write_file_trace_latlon(void) {
         // Close the file
         out_file.close();
         std::cout << "Wrote trace file: " << sec_file_name << std::endl;
+    }
+
+    return 0;
+}
+
+// Write a single trace file for each fault; useful for remeshing long faults with many small segments (eg UCERF3)
+//TODO: Keep track of fault names, add those names to the file name and header
+int quakelib::ModelWorld::write_file_trace_latlon_faultwise(void) {
+    eiterator           eit, last_element;
+    siterator           sit;
+    fiterator           fit;
+    UIndex				fid;
+    UIndex              sid;
+    unsigned int        i;
+    double              max_alt, min_alt, depth_along_dip, section_depth, el_height;
+    bool                element_on_trace;
+    Conversion          c;
+    std::string         fault_file_name, fidstr;
+    std::stringstream	ss;
+
+    // Write traces by fault
+    for (fit=begin_fault(); fit!=end_fault(); ++fit){
+    	std::vector<FaultTracePoint>    trace_pts;
+
+		trace_pts.clear();
+		fid = fit->id();
+		ss << fid;
+		fidstr = ss.str();
+		ss.str("");
+		ss.clear();
+
+		std::ofstream out_file;
+		fault_file_name = "trace_"+fidstr+".txt";
+		out_file.open(fault_file_name.c_str());
+
+
+		for (sit=begin_section(); sit!=end_section(); ++sit) {
+
+			sid = sit->id();
+
+			if (sit->fault_id()==fid){
+
+				// Start by going through all elements
+				max_alt = -DBL_MAX;
+				min_alt = DBL_MAX;
+
+				for (eit=begin_element(sid); eit!=end_element(sid); ++eit) {
+					for (i=0; i<3; ++i) {
+						max_alt = fmax(max_alt, vertex(eit->vertex(i)).xyz()[2]);
+						min_alt = fmin(min_alt, vertex(eit->vertex(i)).xyz()[2]);
+					}
+				}
+
+				// Schultz: Here I am assuming a constant depth for the section.
+				// This should be improved later.
+				section_depth = fabs(max_alt-min_alt);
+
+				// Go through the elements again and grab those which have vertices at the correct depth
+				// TODO: interpolate between elements
+				for (eit=begin_element(sid); eit!=end_element(sid); ++eit) {
+					//Wilson: Sometimes trace points aren't at same height; here we use a quarter-element-height tolerance, or check the trace flag
+					el_height = vertex(eit->vertex(0)).xyz()[2] - vertex(eit->vertex(1)).xyz()[2];
+					element_on_trace = ( (vertex(eit->vertex(0)).xyz()[2] > max_alt-el_height/4.0) && (vertex(eit->vertex(0)).xyz()[2] < max_alt+el_height/4.0) ) || \
+							(vertex(eit->vertex(0)).is_trace() > 0);
+
+					// If the element is on the trace, print it out
+					if (element_on_trace) {
+						Vec<3>      a, b;
+						double      dip_angle;
+						a = vertex(eit->vertex(1)).xyz() - vertex(eit->vertex(0)).xyz();
+						b = vertex(eit->vertex(2)).xyz() - vertex(eit->vertex(0)).xyz();
+						dip_angle = a.cross(b).unit_vector().vector_angle(Vec<3>(0,0,1));
+
+						// Using the dip angle, compute the depth along dip
+						if (dip_angle <= M_PI/2.0) {
+							depth_along_dip = section_depth/sin(dip_angle);
+						} else {
+							depth_along_dip = section_depth/sin(M_PI - dip_angle);
+						}
+
+						FaultTracePoint trace_pt(vertex(eit->vertex(0)).lld(),
+												 depth_along_dip,
+												 c.m_per_sec2cm_per_yr(eit->slip_rate()),
+												 eit->aseismic(),
+												 c.rad2deg(eit->rake()),
+												 c.rad2deg(dip_angle),
+												 eit->lame_mu(),
+												 eit->lame_lambda());
+						trace_pts.push_back(trace_pt);
+						last_element = eit;
+					}
+				}
+
+				Vec<3>      a, b;
+				double      dip_angle;
+				a = vertex(last_element->vertex(1)).xyz() - vertex(last_element->vertex(0)).xyz();
+				b = vertex(last_element->vertex(2)).xyz() - vertex(last_element->vertex(0)).xyz();
+				dip_angle = a.cross(b).unit_vector().vector_angle(Vec<3>(0,0,1));
+				FaultTracePoint trace_pt(vertex(last_element->vertex(2)).lld(),
+										 depth_along_dip,
+										 c.m_per_sec2cm_per_yr(last_element->slip_rate()),
+										 last_element->aseismic(),
+										 c.rad2deg(last_element->rake()),
+										 c.rad2deg(dip_angle),
+										 last_element->lame_mu(),
+										 last_element->lame_lambda());
+				trace_pts.push_back(trace_pt);
+
+			}
+
+		}
+
+        // Write the fault header
+        out_file << "# fault_id: ID number of the parent fault of this section\n";
+        out_file << "# num_points: Number of trace points comprising this section\n";
+        out_file << "# section_name: Name of the section\n";
+
+        // Write out the recorded trace for this fault
+        out_file << fid << " " << trace_pts.size() << " " << fidstr << "\n";
+
+        // Write out the trace point header
+        out_file << "# latitude: Latitude of trace point\n";
+        out_file << "# longitude: Longitude of trace point\n";
+        out_file << "# altitude: Altitude of trace point (meters)\n";
+        out_file << "# depth_along_dip: Depth along dip (meters)\n";
+        out_file << "# slip_rate: Slip rate at trace point (centimeters/year)\n";
+        out_file << "# aseismic: Fraction of slip that is aseismic at point\n";
+        out_file << "# rake: Fault rake at trace point (degrees)\n";
+        out_file << "# dip: Fault dip at trace point (degrees)\n";
+        out_file << "# lame_mu: Lame's mu parameter at trace point (Pascals)\n";
+        out_file << "# lame_lambda: Lame's lambda parameter at trace point (Pascals)\n";
+
+        // And each of the trace points
+        for (i=0; i<trace_pts.size(); ++i) trace_pts[i].write_ascii(out_file);
+
+        // Close the file
+        out_file.close();
+        std::cout << "Wrote trace file: " << fault_file_name << std::endl;
     }
 
     return 0;

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -1403,6 +1403,7 @@ namespace quakelib {
 
             int read_file_trace_latlon(std::vector<unsigned int> &unused_trace_segments, const std::string &file_name, const float &elem_size, const std::string &taper_method, const bool resize_trace_elements);
             int write_file_trace_latlon(void);
+            int write_file_trace_latlon_faultwise(void);
 
             int read_file_hdf5(const std::string &file_name);
             int write_file_hdf5(const std::string &file_name) const;

--- a/src/mesher.cpp
+++ b/src/mesher.cpp
@@ -312,8 +312,8 @@ int main (int argc, char **argv) {
         }
 
         for (n=0; n<types[i].size(); ++n) {
-            if (types[i][n] != "text" && types[i][n] != "hdf5" && types[i][n] != "trace" && types[i][n] != "kml") {
-                std::cerr << "ERROR: " << names[i] << " type must be one of: text, hdf5, trace, kml." << std::endl;
+            if (types[i][n] != "text" && types[i][n] != "hdf5" && types[i][n] != "trace" && types[i][n] != "trace_faultwise" && types[i][n] != "kml") {
+                std::cerr << "ERROR: " << names[i] << " type must be one of: text, hdf5, trace, trace_faultwise, kml." << std::endl;
                 arg_error = true;
             }
 
@@ -449,6 +449,7 @@ int main (int argc, char **argv) {
         else if (types[1][n] == "hdf5") res = world.write_file_hdf5(files[1][n]);
         else if (types[1][n] == "kml") res = world.write_file_kml(files[1][n]);
         else if (types[1][n] == "trace") res = world.write_file_trace_latlon();
+        else if (types[1][n] == "trace_faultwise") res = world.write_file_trace_latlon_faultwise();
 
         if (res) std::cout << "error." << std::endl;
         else std::cout << "done." << std::endl;


### PR DESCRIPTION
trace_faultwise creates a single trace file for each ModelFault.  Useful for remeshing long faults with many small sections (eg UCERF3).

KML outputs now sort sections into fault folders for easy selection.