### PR TITLE
Option for recording DAS by section, Fix gravity coodinate transform

### DIFF
--- a/quakelib/src/QuakeLibElement.cpp
+++ b/quakelib/src/QuakeLibElement.cpp
@@ -243,8 +243,8 @@ quakelib::FloatList quakelib::SlipMap::gravity_changes(const VectorList &points,
             strike_sin = 0.0;
         }
 
-        xp0 = involved_elements[ele_id].vert(0)[0];
-        yp0 = involved_elements[ele_id].vert(0)[1];
+        xp0 = involved_elements[ele_id].vert(1)[0];
+        yp0 = involved_elements[ele_id].vert(1)[1];
 
         xp3 = involved_elements[ele_id].implicit_vert()[0];
         yp3 = involved_elements[ele_id].implicit_vert()[1];
@@ -341,8 +341,8 @@ quakelib::FloatList quakelib::SlipMap::dilat_gravity_changes(const VectorList &p
             strike_sin = 0.0;
         }
 
-        xp0 = involved_elements[ele_id].vert(0)[0];
-        yp0 = involved_elements[ele_id].vert(0)[1];
+        xp0 = involved_elements[ele_id].vert(1)[0];
+        yp0 = involved_elements[ele_id].vert(1)[1];
 
         xp3 = involved_elements[ele_id].implicit_vert()[0];
         yp3 = involved_elements[ele_id].implicit_vert()[1];
@@ -423,8 +423,8 @@ quakelib::VectorList quakelib::SlipMap::displacements(const VectorList &points, 
             strike_sin = 0.0;
         }
 
-        xp0 = involved_elements[ele_id].vert(0)[0];
-        yp0 = involved_elements[ele_id].vert(0)[1];
+        xp0 = involved_elements[ele_id].vert(1)[0];
+        yp0 = involved_elements[ele_id].vert(1)[1];
 
         /*
         std::cout << "v1: <" << involved_elements[ele_id].vert(0)[0] << ", " << involved_elements[ele_id].vert(0)[1] << ", " << involved_elements[ele_id].vert(0)[2] << ">" << std::endl;
@@ -527,8 +527,8 @@ quakelib::FloatList quakelib::SlipMap::potential_changes(const VectorList &point
             strike_sin = 0.0;
         }
 
-        xp0 = involved_elements[ele_id].vert(0)[0];
-        yp0 = involved_elements[ele_id].vert(0)[1];
+        xp0 = involved_elements[ele_id].vert(1)[0];
+        yp0 = involved_elements[ele_id].vert(1)[1];
 
         xp3 = involved_elements[ele_id].implicit_vert()[0];
         yp3 = involved_elements[ele_id].implicit_vert()[1];

--- a/quakelib/src/QuakeLibElement.cpp
+++ b/quakelib/src/QuakeLibElement.cpp
@@ -275,8 +275,8 @@ quakelib::FloatList quakelib::SlipMap::gravity_changes(const VectorList &points,
                 gravity_change = 0.0;
             } else {
 
-                xp = (x-xp0) * strike_sin - (y-yp0) * strike_cos;
-                yp = (x-xp0) * strike_cos + (y-yp0) * strike_sin;
+                xp = (x-xp0) * strike_sin + (y-yp0) * strike_cos;
+                yp = -(x-xp0) * strike_cos + (y-yp0) * strike_sin;
 
                 gravity_change = block_okada.calc_dg(quakelib::Vec<2>(xp,yp), c, dip, L, W, US, UD, UT, lambda, mu);
 
@@ -358,8 +358,8 @@ quakelib::FloatList quakelib::SlipMap::dilat_gravity_changes(const VectorList &p
                 gravity_change = 0.0;
             } else {
 
-                xp = (x-xp0) * strike_sin - (y-yp0) * strike_cos;
-                yp = (x-xp0) * strike_cos + (y-yp0) * strike_sin;
+            	xp = (x-xp0) * strike_sin + (y-yp0) * strike_cos;
+				yp = -(x-xp0) * strike_cos + (y-yp0) * strike_sin;
 
                 gravity_change = block_okada.calc_dg_dilat(quakelib::Vec<2>(xp,yp), c, dip, L, W, US, UD, UT, lambda, mu);
             }
@@ -453,8 +453,8 @@ quakelib::VectorList quakelib::SlipMap::displacements(const VectorList &points, 
                 dy = 0.0;
                 dz = 0.0;
             } else {
-                xp = (x-xp0) * strike_sin - (y-yp0) * strike_cos;
-                yp = (x-xp0) * strike_cos + (y-yp0) * strike_sin;
+            	xp = (x-xp0) * strike_sin + (y-yp0) * strike_cos;
+				yp = -(x-xp0) * strike_cos + (y-yp0) * strike_sin;
 
                 displacement = block_okada.calc_displacement_vector(quakelib::Vec<3>(xp,yp,0.0), c, dip, L, W, US, UD, UT, lambda, mu);
 
@@ -544,8 +544,8 @@ quakelib::FloatList quakelib::SlipMap::potential_changes(const VectorList &point
                 potential_change = 0.0;
             } else {
 
-                xp = (x-xp0) * strike_sin - (y-yp0) * strike_cos;
-                yp = (x-xp0) * strike_cos + (y-yp0) * strike_sin;
+            	xp = (x-xp0) * strike_sin + (y-yp0) * strike_cos;
+				yp = -(x-xp0) * strike_cos + (y-yp0) * strike_sin;
 
                 // CHANGE this to enable dV calculations below z=0
                 zp = 0.0;

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -805,7 +805,7 @@ void quakelib::ModelWorld::create_faults_minimal(void) {
 
 
 
-void quakelib::ModelWorld::create_faults(const std::string &taper_method) {
+void quakelib::ModelWorld::create_faults(const std::string &taper_method, const bool &vertDASbysec) {
     std::map<UIndex, ModelFault>::const_iterator fit;
     std::map<UIndex, ModelSection>::const_iterator sit;
     std::map<UIndex, ModelElement>::iterator eit;
@@ -861,10 +861,12 @@ void quakelib::ModelWorld::create_faults(const std::string &taper_method) {
         }
     }
 
-    // Re-record each vertex DAS as it's currently known section DAS + DAS at beginning of section
-    for (vit=_vertices.begin(); vit!=_vertices.end(); vit++) {
-        vit->second.set_das(vit->second.das() + sectStartDAS[vertSects[vit->second.id()]]);
-    }
+    if (vertDASbysec == true){
+		// Re-record each vertex DAS as it's currently known section DAS + DAS at beginning of section
+		for (vit=_vertices.begin(); vit!=_vertices.end(); vit++) {
+			vit->second.set_das(vit->second.das() + sectStartDAS[vertSects[vit->second.id()]]);
+		}
+	}
 
     // If tapering, loop through elements, calc their midpoint DAS,
     // assign horizontal sqrt tapering in end 12km.

--- a/quakelib/src/QuakeLibIO.cpp
+++ b/quakelib/src/QuakeLibIO.cpp
@@ -788,6 +788,7 @@ void quakelib::ModelWorld::create_faults_minimal(void) {
 
         if (_faults.count(sit->second.fault_id())==0) {
             ModelFault &fault = new_fault(sit->second.fault_id());
+            fault.set_name(sit->second.name()); // Currently uses first section's name as fault name
             fault.insert_section_id(sit->first);
             fault.set_length(0.0);
             fault.set_area(0.0);

--- a/quakelib/src/QuakeLibIO.h
+++ b/quakelib/src/QuakeLibIO.h
@@ -1406,7 +1406,7 @@ namespace quakelib {
                                 const UIndex &sec_id = -1);
 
             void compute_stress_drops(const double &stress_drop_factor);
-            void create_faults(const std::string &taper_method);
+            void create_faults(const std::string &taper_method, const bool &vertDASbysec = false);
             void create_faults_minimal(void);
 
             int read_file_ascii(const std::string &file_name);


### PR DESCRIPTION
- Included option to record vertex distance along strike with respect to the beginning of sections (old behavior).

- Coordinate transforms for plotting gravity field changes are now fixed.