### PR TITLE
Add post cleanup to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,4 +94,9 @@ pipeline {
       }
     }
   }
+  post {
+    cleanup {
+      deleteDir()
+    }
+  }
 }


### PR DESCRIPTION
Apparently, despite using ephemeral containers, Jenkins still likes to leave files behind. 
Got the fix from here: https://stackoverflow.com/questions/37468455/jenkins-pipeline-wipe-out-workspace 