### PR TITLE
Switch CI to autobuilt Docker container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,11 +14,6 @@ pipeline {
     }
   }
 
-  environment {
-    DEBIAN_FRONTEND = 'noninteractive'
-    DEBCONF_NONINTERACTIVE_SEEN = 'true'
-  }
-
   options {
     timeout(time: 4, unit: 'HOURS')
   }


### PR DESCRIPTION
The autobuild system seems to be fairly straightforward. I'm still not sure about the best tagging convention. It seems to be more geared to having Dockerfiles in their own separate repo.

If this works, I'll try to get a parallel CI build using both Xenial and Bionic.

Here's the buildenv container link: https://hub.docker.com/r/geodynamics/virtualquake-buildenv-xenial/