### PR TITLE
Add apt noninteractive envvars to apt call

### DIFF
--- a/docker/virtualquake-buildenv-bionic/Dockerfile
+++ b/docker/virtualquake-buildenv-bionic/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:bionic
 
-RUN apt update && apt install --yes \
+RUN DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt update && apt install --yes \
   build-essential \
   cmake \
   doxygen \

--- a/docker/virtualquake-buildenv-xenial/Dockerfile
+++ b/docker/virtualquake-buildenv-xenial/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:xenial
 
-RUN apt update && apt install --yes \
+RUN DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt update && apt install --yes \
   build-essential \
   cmake \
   doxygen \


### PR DESCRIPTION
DockerHub was able to build the Xenial buildenv, but I added them to both just to be safe.

I didn't use the `ENV` Dockerfile directive because, as the Docker documentation [points out](https://docs.docker.com/engine/reference/builder/#env),

> Note: Environment persistence can cause unexpected side effects. For example, setting ENV DEBIAN_FRONTEND noninteractive may confuse apt-get users on a Debian-based image. To set a value for a single command, use RUN <key>=<value> <command>.

This is only a build environment, so if you feel strongly one way or the other, I'd be willing to change to using `ENV`.

