### PR TITLE
Fix temp envvar declaration

### DIFF
--- a/docker/virtualquake-buildenv-bionic/Dockerfile
+++ b/docker/virtualquake-buildenv-bionic/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:bionic
 
-RUN DEBIAN_FRONTEND='noninteractive' \
+RUN apt update && \
+  DEBIAN_FRONTEND='noninteractive' \
   DEBCONF_NONINTERACTIVE_SEEN='true' \
-  apt update && apt install --yes \
+  apt install --yes \
   build-essential \
   cmake \
   doxygen \

--- a/docker/virtualquake-buildenv-xenial/Dockerfile
+++ b/docker/virtualquake-buildenv-xenial/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:xenial
 
-RUN DEBIAN_FRONTEND='noninteractive' \
+RUN apt update && \
+  DEBIAN_FRONTEND='noninteractive' \
   DEBCONF_NONINTERACTIVE_SEEN='true' \
-  apt update && apt install --yes \
+  apt install --yes \
   build-essential \
   cmake \
   doxygen \


### PR DESCRIPTION
How embarrassing, I thought I had tested #201 correctly.

The error is that temporary envvar declarations don't carry over when chaining processes together.

As an example:

``` bash
$ TEST='set' eval 'echo envvar is $TEST' && eval 'echo envvar is $TEST'
envvar is set
envvar is 
$
```